### PR TITLE
fix(editor): triangle plus buttons sit on body edges/corners

### DIFF
--- a/components/editor/geometry.ts
+++ b/components/editor/geometry.ts
@@ -315,11 +315,21 @@ const triangleGeometry: ShapeGeometry<'triangle'> = {
     return undefined
   },
   plusAnchor: (_p, slot, _sub, n) => {
-    if (slot === 'up')     return { x: triApexX(n), y: triApexY(n) - 30, position: Position.Top    }
-    if (slot === 'down')   return { x: n / 2,       y: triBaseY(n) + 30, position: Position.Bottom }
-    if (slot === 'left')   return { x: -30,         y: triCenterY(n),    position: Position.Left   }
-    if (slot === 'right')  return { x: n + 30,      y: triCenterY(n),    position: Position.Right  }
-    if (slot === 'center') return { x: n / 2,       y: triCenterY(n),    position: Position.Top    }
+    // Plus buttons sit ON the triangle's edges and corners — same convention
+    // as rhombus and rectangle. The apex is the up-slot corner, the base
+    // midpoint is the down-slot anchor, and left/right plus sit at the
+    // midpoint of each slanted edge.
+    if (slot === 'up')     return { x: triApexX(n), y: triApexY(n),    position: Position.Top    }
+    if (slot === 'down')   return { x: n / 2,       y: triBaseY(n),    position: Position.Bottom }
+    if (slot === 'left')   {
+      const [x, y] = triSlantPt('left', 0.5, n)
+      return { x, y, position: Position.Left }
+    }
+    if (slot === 'right')  {
+      const [x, y] = triSlantPt('right', 0.5, n)
+      return { x, y, position: Position.Right }
+    }
+    if (slot === 'center') return { x: n / 2, y: triCenterY(n), position: Position.Top }
     if (slot === 'total')  return frameNWAnchor(triangleBody, n)
     return undefined
   },


### PR DESCRIPTION
## Summary

Triangle plus buttons were positioned 30px OUTSIDE the body (left of left, right of right, above the apex, below the base) — a "wing" style that diverged from rhombus/rectangle, both of which place plus buttons ON the body edges and corners. Aligned the convention.

### Changes

In `components/editor/geometry.ts:triangleGeometry.plusAnchor`:
- `up` → apex corner: `(triApexX, triApexY)`
- `down` → base midpoint: `(n/2, triBaseY)`
- `left` → midpoint of left slanted edge via `triSlantPt('left', 0.5)`
- `right` → midpoint of right slanted edge via `triSlantPt('right', 0.5)`
- `center`, `total` → unchanged (already inside-body / at frame NW)

### Side effect

All triangle plus buttons now render as SMALL (not LARGE wings) since every anchor is within the body box `[0..n]²`. Same size class as the equivalent rhombus / rectangle plus buttons. The `large` flag in `DiagramNode.tsx` is anchor-position-derived (`anchor.x < 0 || anchor.x > n || ...`), not per-kind hardcoded — so the size adjusts automatically from the new anchor positions.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Triangle plus buttons render at apex / base midpoint / slanted-edge midpoints / center / NW (6 total)
- [ ] Reviewer: spot-check a triangle in the editor — plus buttons should sit on the body outline like rhombus/rectangle

🤖 Generated with [Claude Code](https://claude.com/claude-code)