### PR TITLE
fix(editor): rename no longer bridges through carrier siblings + doc cleanup

### DIFF
--- a/components/editor/geometry.ts
+++ b/components/editor/geometry.ts
@@ -143,12 +143,24 @@ export interface ShapeGeometry<K extends ShapeKind> {
   // returns the subslot the new point should land in (undefined ⇒ no subslot).
   // Replaces hard-coded `kind === 'rhombus' || kind === 'rectangle'` switches in Canvas.
   dropSubslot: (slot: Slot, ry: number) => Subslot | undefined
-  // True if this kind is a carrier — a wrapper kind whose body has no meaning
-  // beyond holding inner points. Carriers self-delete when their last inner
-  // point is removed (orphan-cleanup in mutations.ts). NOTE: carriers do NOT
-  // share identity with their inner points — sibling points inside a carrier
-  // are still SEPARATE referents at distinct slots, and renaming one does not
-  // propagate to the others. False for kinds whose body itself is meaningful.
+  // True if this kind is a carrier — a transient wrapper whose identity IS
+  // its payload (its inner point), not its body. Two consumer behaviors flow
+  // from this single semantic role:
+  //
+  //   1. Orphan-cleanup (mutations.ts): when the last inner point is removed,
+  //      the carrier is deleted from the diagram (no body to leave behind).
+  //   2. Drag-to-attach (Canvas.tsx onNodeDragStop): dragging a single-shape
+  //      carrier onto another shape re-parents the carrier's inner point
+  //      INTO that shape — the user is interpreted as moving the payload.
+  //
+  // Both behaviors derive from "carrier IS its payload"; non-carrier kinds
+  // (rectangle, circle, etc.) have meaningful bodies and skip both behaviors.
+  //
+  // NOTE: carriers do NOT share identity ACROSS their sibling inner points —
+  // a carrier holding multiple points (left + center + right) has SEPARATE
+  // referents at each slot; renaming one does not propagate to the others.
+  // The carrier-ness is about the wrapper-vs-payload relationship, not about
+  // sibling identity.
   isCarrier: boolean
   // Plural label shown in the Kinds visibility menu.
   displayName: string

--- a/components/editor/geometry.ts
+++ b/components/editor/geometry.ts
@@ -143,11 +143,12 @@ export interface ShapeGeometry<K extends ShapeKind> {
   // returns the subslot the new point should land in (undefined ⇒ no subslot).
   // Replaces hard-coded `kind === 'rhombus' || kind === 'rectangle'` switches in Canvas.
   dropSubslot: (slot: Slot, ry: number) => Subslot | undefined
-  // True if this kind is a carrier — a wrapper that exists only to hold inner
-  // points, with no meaningful identity of its own. Carriers self-delete when
-  // their inner points are removed (mutations cleanup) AND their inner points
-  // bridge identity with the outer (rename propagation through referent BFS).
-  // False for kinds whose body itself is meaningful (triangle, circle, etc.).
+  // True if this kind is a carrier — a wrapper kind whose body has no meaning
+  // beyond holding inner points. Carriers self-delete when their last inner
+  // point is removed (orphan-cleanup in mutations.ts). NOTE: carriers do NOT
+  // share identity with their inner points — sibling points inside a carrier
+  // are still SEPARATE referents at distinct slots, and renaming one does not
+  // propagate to the others. False for kinds whose body itself is meaningful.
   isCarrier: boolean
   // Plural label shown in the Kinds visibility menu.
   displayName: string

--- a/components/editor/mutations.ts
+++ b/components/editor/mutations.ts
@@ -204,13 +204,11 @@ function walkToPath(top: AnyShape, path: { slot: Slot; subslot?: Subslot; index:
 
 // Same name = same referent. Renaming one point propagates to every other
 // shape in its connected referent component:
-//   • Line connectivity: source ↔ all targets of any line they share.
-//   • Empty-container bridge: all inner points of an empty share its identity
-//     (the empty IS a point of identity; its inner-point slots are different
-//     visual occurrences of the same referent).
-// Without this, renaming "P1" → "x" on one occurrence leaves the other
-// connected occurrences stuck on the old "P1" — they visibly desynchronize
-// from a referent they're supposed to share.
+//   • Line connectivity ONLY: source ↔ all targets of any line they share.
+// Sibling points inside the same parent (e.g. left/center/right of an empty)
+// are SEPARATE referents — they live at distinct slots and have their own
+// identities; renaming one must not propagate to the others. Same rule for
+// every kind, no carrier exception.
 export function renamePoint(d: Diagram, id: string, newName: string): Diagram {
   if (!newName.trim()) return d
   const component = referentComponent(d, id)
@@ -229,17 +227,6 @@ function referentComponent(d: Diagram, startId: string): Set<string> {
       if (!refs.includes(cur)) continue
       for (const r of refs) {
         if (!seen.has(r)) { seen.add(r); queue.push(r) }
-      }
-    }
-    // Carrier kinds (per geom.isCarrier) have no identity of their own — their
-    // inner points share identity with the carrier, so the BFS bridges through
-    // them. Non-carrier kinds stop the bridge here.
-    const loc = findShape(d, cur)
-    if (!loc || loc.topContainer !== 'nodes' || !geometryFor(loc.topShape.kind).isCarrier) continue
-    for (const inner of walkShape(loc.topShape)) {
-      if (inner.id !== loc.topShape.id && !seen.has(inner.id)) {
-        seen.add(inner.id)
-        queue.push(inner.id)
       }
     }
   }


### PR DESCRIPTION
## Summary

Two commits.

### 82594a6 — bug fix

Renaming a point inside an empty carrier was incorrectly renaming ALL sibling points inside the same empty (e.g. left, center, right all set to the same string when only the total was renamed). The bug was in \`referentComponent\`'s "carrier bridge": when the BFS visited any inner point of a carrier, it added EVERY inner point to the rename set.

The bridge was a misgeneralization of the \`isCarrier\` flag — it conflated two ideas under one mechanism:
- **Cleanup behavior**: empties auto-delete when their last inner point is removed. (Real, kept.)
- **Identity sharing**: inner points share identity with the carrier. (Wrong — sibling points at distinct slots are SEPARATE referents.)

Removed the bridge entirely. \`referentComponent\` now walks the line graph ONLY. Same rule for every kind:
- Rename via line connectivity → propagates to line-connected points (correct).
- Sibling points inside the same parent → independent (correct).

Note for context: this bug only manifested for empties because \`isCarrier: true\` is empty-only — non-carrier kinds (rectangle, circle, etc.) skipped the bridge and behaved correctly. Removing the bridge unifies behavior across kinds.

### 0b6b0d8 — doc cleanup

Expanded the \`isCarrier\` doc comment in \`geometry.ts\` to cover both real consumers of the flag (orphan-cleanup AND drag-to-attach) instead of just cleanup, plus the explicit non-property "carriers do NOT share identity across sibling inner points" so the bug above can't reappear.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Renaming a point inside an empty (with multiple inner points) updates ONLY that point — siblings keep their own names
- [x] Renaming a point connected by a line to another point still propagates via the line graph
- [x] Drag-to-attach (drag an empty onto another shape) still works (uses isCarrier)
- [x] Orphan cleanup (delete the last inner point of an empty) still removes the empty (uses isCarrier)
- [ ] Reviewer: reproduce the original bug (create empty with multiple inner points, rename one, confirm only that one renames now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)