### PR TITLE
fix(editor): line label collision avoidance — single-pass greedy MIS with accurate handle positions

### DIFF
--- a/components/editor/Canvas.tsx
+++ b/components/editor/Canvas.tsx
@@ -261,16 +261,29 @@ function Canvas() {
     // collide in screen space (e.g. two parallel lines running close together).
     // Greedy placement: walk edges in id order, for each one try labelFraction
     // candidates until one places the label box without overlapping any
-    // previously-placed label. Approximates the line endpoint as the source/
-    // target node center — good enough for collision detection.
-    const nodeCenter = new Map<string, { cx: number; cy: number }>()
-    for (const node of diagram.nodes) {
+    // previously-placed label.
+    //
+    // Endpoint resolver uses the EXACT handle position (`parseHandle` +
+    // `geom.pointAnchor`) — same coordinates DiagramEdge renders the line at,
+    // so the collision detector matches the rendered geometry. (Approximating
+    // as node centers had a small but real bias, which let some labels collide
+    // visually while looking non-colliding to the heuristic.)
+    const endpointPosition = (
+      nodeId: string,
+      handleId: string | null | undefined,
+    ): { x: number; y: number } | undefined => {
+      if (!handleId) return undefined
+      const node = diagram.nodes.find((n) => n.id === nodeId)
+      if (!node) return undefined
       const g = geometryFor(node.kind)
-      const half = g.nodeSize(node.points as never) / 2
-      nodeCenter.set(node.id, {
-        cx: node.transform.space.translation[0] + half,
-        cy: node.transform.space.translation[1] + half,
-      })
+      const n = g.nodeSize(node.points as never)
+      const { slot, subslot, index } = parseHandle(handleId)
+      const anchor = g.pointAnchor(node.points as never, slot, subslot, index, n)
+      if (!anchor) return undefined
+      return {
+        x: node.transform.space.translation[0] + anchor.x,
+        y: node.transform.space.translation[1] + anchor.y,
+      }
     }
     const TRY_FRACTIONS = [0.5, 0.4, 0.6, 0.35, 0.65, 0.3, 0.7, 0.25, 0.75, 0.2, 0.8]
     interface Box { x: number; y: number; w: number; h: number }
@@ -279,15 +292,15 @@ function Canvas() {
     const placed: Box[] = []
     const sortedEdges = [...out].sort((a, b) => a.id.localeCompare(b.id))
     for (const e of sortedEdges) {
-      const a = nodeCenter.get(e.source)
-      const b = nodeCenter.get(e.target)
+      const a = endpointPosition(e.source, e.sourceHandle)
+      const b = endpointPosition(e.target, e.targetHandle)
       if (!a || !b) continue
       const label = (e.data as { label?: string })?.label ?? ''
       const w = label.length * CHAR_W + LABEL_PADDING
       const initialT = (e.data as { labelFraction?: number })?.labelFraction ?? 0.5
       const candidates = [initialT, ...TRY_FRACTIONS.filter((t) => t !== initialT)]
-      const xAt = (t: number) => a.cx + (b.cx - a.cx) * t
-      const yAt = (t: number) => a.cy + (b.cy - a.cy) * t
+      const xAt = (t: number) => a.x + (b.x - a.x) * t
+      const yAt = (t: number) => a.y + (b.y - a.y) * t
       let chosen = initialT
       for (const t of candidates) {
         const box: Box = { x: xAt(t), y: yAt(t), w, h: LABEL_HEIGHT }

--- a/components/editor/Canvas.tsx
+++ b/components/editor/Canvas.tsx
@@ -222,18 +222,16 @@ function Canvas() {
         })
       })
     }
-    // Label anti-overlap: group edges by the DIRECTED (source,target) pair
-    // (bidirectional pairs stay in separate groups — otherwise symmetric
-    // offsets push labels the same way in world space and merge instead of
-    // separating).
+    // === PASS 1: per-pair label spread ===
+    // Group edges by the DIRECTED (source, target) pair (bidirectional pairs
+    // stay in separate groups — otherwise symmetric offsets push labels the
+    // same way in world space and merge instead of separating).
     //
     // Only nudge when the widest label in a group is wide enough to hard-
-    // overlap at the midpoint. Short labels (≲ NUDGE_THRESHOLD_PX) keep their
-    // natural midpoint. Wide ones get a GENTLE centered spread around 0.5
-    // (step 0.1 per index) so labels stay near the line center instead of
-    // being pushed toward the endpoints.
+    // overlap at the midpoint. Short labels keep their natural midpoint.
     const CHAR_W = 7
     const LABEL_PADDING = 16
+    const LABEL_HEIGHT = 22
     const NUDGE_THRESHOLD_PX = 100
     const STEP = 0.1
     const groups = new Map<string, Edge[]>()
@@ -256,6 +254,52 @@ function Canvas() {
         const fraction = 0.5 + (i - mid) * STEP
         e.data = { ...(e.data ?? {}), labelFraction: fraction }
       })
+    }
+
+    // === PASS 2: cross-pair spatial collision avoidance ===
+    // Two edges between DIFFERENT node pairs can still have their label boxes
+    // collide in screen space (e.g. two parallel lines running close together).
+    // Greedy placement: walk edges in id order, for each one try labelFraction
+    // candidates until one places the label box without overlapping any
+    // previously-placed label. Approximates the line endpoint as the source/
+    // target node center — good enough for collision detection.
+    const nodeCenter = new Map<string, { cx: number; cy: number }>()
+    for (const node of diagram.nodes) {
+      const g = geometryFor(node.kind)
+      const half = g.nodeSize(node.points as never) / 2
+      nodeCenter.set(node.id, {
+        cx: node.transform.space.translation[0] + half,
+        cy: node.transform.space.translation[1] + half,
+      })
+    }
+    const TRY_FRACTIONS = [0.5, 0.4, 0.6, 0.35, 0.65, 0.3, 0.7, 0.25, 0.75, 0.2, 0.8]
+    interface Box { x: number; y: number; w: number; h: number }
+    const overlap = (a: Box, b: Box) =>
+      Math.abs(a.x - b.x) < (a.w + b.w) / 2 && Math.abs(a.y - b.y) < (a.h + b.h) / 2
+    const placed: Box[] = []
+    const sortedEdges = [...out].sort((a, b) => a.id.localeCompare(b.id))
+    for (const e of sortedEdges) {
+      const a = nodeCenter.get(e.source)
+      const b = nodeCenter.get(e.target)
+      if (!a || !b) continue
+      const label = (e.data as { label?: string })?.label ?? ''
+      const w = label.length * CHAR_W + LABEL_PADDING
+      const initialT = (e.data as { labelFraction?: number })?.labelFraction ?? 0.5
+      const candidates = [initialT, ...TRY_FRACTIONS.filter((t) => t !== initialT)]
+      const xAt = (t: number) => a.cx + (b.cx - a.cx) * t
+      const yAt = (t: number) => a.cy + (b.cy - a.cy) * t
+      let chosen = initialT
+      for (const t of candidates) {
+        const box: Box = { x: xAt(t), y: yAt(t), w, h: LABEL_HEIGHT }
+        if (!placed.some((p) => overlap(p, box))) {
+          chosen = t
+          break
+        }
+      }
+      placed.push({ x: xAt(chosen), y: yAt(chosen), w, h: LABEL_HEIGHT })
+      if (chosen !== initialT) {
+        e.data = { ...(e.data ?? {}), labelFraction: chosen }
+      }
     }
     return out
   }, [diagram, visibility.lines, renameLine])

--- a/components/editor/Canvas.tsx
+++ b/components/editor/Canvas.tsx
@@ -222,52 +222,27 @@ function Canvas() {
         })
       })
     }
-    // === PASS 1: per-pair label spread ===
-    // Group edges by the DIRECTED (source, target) pair (bidirectional pairs
-    // stay in separate groups — otherwise symmetric offsets push labels the
-    // same way in world space and merge instead of separating).
+    // === Greedy MIS label placement (single pass) ===
+    // Industry-standard generic post-processing for edge label overlap (cf.
+    // yWorks GreedyMISLabeling on a DiscreteEdgeLabelModel). Walk edges in
+    // id order; for each, try a discrete set of `labelFraction` candidates
+    // along its line and place at the first one whose label box doesn't
+    // overlap an already-placed label. If everything collides, keep the
+    // initial midpoint and accept the residual overlap.
     //
-    // Only nudge when the widest label in a group is wide enough to hard-
-    // overlap at the midpoint. Short labels keep their natural midpoint.
+    // Multi-edges between the same source / target don't need a separate
+    // pre-spread: they all start at fraction 0.5, and the greedy collision
+    // detection nudges every-but-the-first to the alternative fractions.
+    // No magic NUDGE_THRESHOLD — narrow labels stay at midpoint when they
+    // don't actually collide.
+    //
+    // Endpoint resolver uses the EXACT handle position (`parseHandle` +
+    // `geom.pointAnchor`) — same coordinates DiagramEdge renders the line
+    // at, so the collision detector matches the rendered geometry.
     const CHAR_W = 7
     const LABEL_PADDING = 16
     const LABEL_HEIGHT = 22
-    const NUDGE_THRESHOLD_PX = 100
-    const STEP = 0.1
-    const groups = new Map<string, Edge[]>()
-    for (const e of out) {
-      const key = `${e.source}|${e.target}`
-      const list = groups.get(key) ?? []
-      list.push(e)
-      groups.set(key, list)
-    }
-    for (const group of groups.values()) {
-      if (group.length < 2) continue
-      const maxLabelWidth = Math.max(...group.map((e) => {
-        const label = (e.data as { label?: string })?.label ?? ''
-        return label.length * CHAR_W + LABEL_PADDING
-      }))
-      if (maxLabelWidth < NUDGE_THRESHOLD_PX) continue
-      group.sort((a, b) => a.id.localeCompare(b.id))
-      const mid = (group.length - 1) / 2
-      group.forEach((e, i) => {
-        const fraction = 0.5 + (i - mid) * STEP
-        e.data = { ...(e.data ?? {}), labelFraction: fraction }
-      })
-    }
-
-    // === PASS 2: cross-pair spatial collision avoidance ===
-    // Two edges between DIFFERENT node pairs can still have their label boxes
-    // collide in screen space (e.g. two parallel lines running close together).
-    // Greedy placement: walk edges in id order, for each one try labelFraction
-    // candidates until one places the label box without overlapping any
-    // previously-placed label.
-    //
-    // Endpoint resolver uses the EXACT handle position (`parseHandle` +
-    // `geom.pointAnchor`) — same coordinates DiagramEdge renders the line at,
-    // so the collision detector matches the rendered geometry. (Approximating
-    // as node centers had a small but real bias, which let some labels collide
-    // visually while looking non-colliding to the heuristic.)
+    const TRY_FRACTIONS = [0.5, 0.4, 0.6, 0.35, 0.65, 0.3, 0.7, 0.25, 0.75, 0.2, 0.8]
     const endpointPosition = (
       nodeId: string,
       handleId: string | null | undefined,
@@ -285,7 +260,6 @@ function Canvas() {
         y: node.transform.space.translation[1] + anchor.y,
       }
     }
-    const TRY_FRACTIONS = [0.5, 0.4, 0.6, 0.35, 0.65, 0.3, 0.7, 0.25, 0.75, 0.2, 0.8]
     interface Box { x: number; y: number; w: number; h: number }
     const overlap = (a: Box, b: Box) =>
       Math.abs(a.x - b.x) < (a.w + b.w) / 2 && Math.abs(a.y - b.y) < (a.h + b.h) / 2
@@ -297,12 +271,10 @@ function Canvas() {
       if (!a || !b) continue
       const label = (e.data as { label?: string })?.label ?? ''
       const w = label.length * CHAR_W + LABEL_PADDING
-      const initialT = (e.data as { labelFraction?: number })?.labelFraction ?? 0.5
-      const candidates = [initialT, ...TRY_FRACTIONS.filter((t) => t !== initialT)]
       const xAt = (t: number) => a.x + (b.x - a.x) * t
       const yAt = (t: number) => a.y + (b.y - a.y) * t
-      let chosen = initialT
-      for (const t of candidates) {
+      let chosen = 0.5
+      for (const t of TRY_FRACTIONS) {
         const box: Box = { x: xAt(t), y: yAt(t), w, h: LABEL_HEIGHT }
         if (!placed.some((p) => overlap(p, box))) {
           chosen = t
@@ -310,7 +282,7 @@ function Canvas() {
         }
       }
       placed.push({ x: xAt(chosen), y: yAt(chosen), w, h: LABEL_HEIGHT })
-      if (chosen !== initialT) {
+      if (chosen !== 0.5) {
         e.data = { ...(e.data ?? {}), labelFraction: chosen }
       }
     }


### PR DESCRIPTION
## Summary

Fixes line labels rendering on top of each other when two edges' label boxes happen to land in the same place on screen. Three commits, building on each other; the final state is a clean industry-standard generic post-processing pass.

### e5299f6 — initial spatial collision avoidance

The pre-existing label anti-overlap logic only spread labels for multiple edges sharing the same `(source, target)` pair. Two edges between DIFFERENT pairs whose labels happened to land near each other slipped through and rendered overlapping.

Added a greedy spatial collision pass: for each edge in id order, try the current `labelFraction` first, then alternative fractions (0.4, 0.6, 0.35, 0.65, … 0.2/0.8). First fraction whose label box doesn't overlap any previously-placed label wins. If everything collides, keep initial — same as before for that one edge.

### 4274239 — accuracy fix: use real handle positions, not node centers

The first version approximated each line endpoint as the source/target NODE CENTER. But labels render along the line between actual HANDLE positions, which can be meaningfully different (e.g. a line going from a `center.center` handle to an `up` handle). The collision detector was reading positions where labels DON'T render, so it could miss real collisions and flag false ones.

Replaced the `nodeCenter` Map with an `endpointPosition` helper that combines `parseHandle` (handle id grammar) with `geometryFor(...).pointAnchor(...)` (per-kind, per-slot pixel offset within the node) to compute the EXACT same coordinates DiagramEdge renders the line at. Same algorithm, accurate inputs.

### 4d09b4b — unify the two passes into one

Removed the separate "Pass 1: per-pair label spread" that ran before the spatial collision pass. Per yWorks documentation and the academic literature on edge label placement, the standard approach is a SINGLE-PASS `GreedyMISLabeling` on a discrete candidate set — no special pre-spread heuristic for parallel edges between the same nodes.

Why Pass 1 was redundant:
- Multi-edges between the same source / target naturally start at the same fraction (0.5). The greedy collision detector nudges every-but-the-first to alternative fractions. Same end result as the explicit per-pair spread, without the special-case code path.

Why Pass 1 was slightly wrong:
- It gated on \`NUDGE_THRESHOLD_PX = 100\` (only spread when the widest label was wide enough to definitely overlap at midpoint). Narrow multi-edge labels stayed stacked. The unified pass triggers spread whenever there's actual collision regardless of label width.

Net: ~30 lines deleted, simpler control flow, behavior more uniform.

## Algorithmic basis

This implementation is exactly **\`GreedyMISLabeling\` on a \`DiscreteEdgeLabelModel\`** in yWorks taxonomy. Eleven discrete candidate fractions along the line (0.5, 0.4, 0.6, 0.35, 0.65, 0.3, 0.7, 0.25, 0.75, 0.2, 0.8). Greedy: walk edges in id order, place each at the first non-colliding candidate. O(n²) AABB collision check.

React Flow has no built-in solution and explicitly defers to user-space ("too many use cases"). Heavier alternatives exist:
- **Simulated Annealing** (D3-Labeler): better for hard cases, ~1000 sweeps.
- **\`SliderEdgeLabelModel\`** (yWorks): continuous candidates rather than discrete.
- **PRISM**: force-based iterative overlap removal.

Deferred unless the simple version proves insufficient.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Reproduces the user's reported case (two parallel lines, labels were rendering on top of each other; now spread to different fractions along their respective lines)
- [x] Multi-edges between the same source/target spread correctly (same code path; greedy MIS handles it without a per-pair pre-pass)
- [x] Sample diagrams (CSG, DatabaseVorlesung2, aristotLOGIK, hero) render without label regressions
- [ ] Reviewer: confirm visual fidelity in production

## Sources informing this work

- [yWorks: Demystifying Automatic Edge Labeling](http://kb.yworks.com/article/52/)
- [yWorks: Minimizing Label Overlaps](http://kb.yworks.com/article/276/Minimizing-Label-Overlaps)
- [D3-Labeler — simulated annealing for label placement](https://github.com/tinker10/D3-Labeler)
- [React Flow issue #819 — overlapping edge labels](https://github.com/wbkd/react-flow/issues/819)
- [Graphviz: Drawing Directed Graphs (Gansner & Koutsofios)](https://www.graphviz.org/documentation/TSE93.pdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)