### PR TITLE
Editor: empty scale, total visibility fix, wider zoom range

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -153,11 +153,16 @@ input[type="search"]::-webkit-search-results-decoration {
   will-change: stroke-dashoffset;
 }
 
-/* Hide point dots and labels via CSS when the Points toggle is off. The
-   total slot is exempt — it carries the shape's identity anchor (its label
-   is the shape's name), so each shape stays addressable when Points are
-   hidden. */
-.points-hidden .react-flow__handle:not(.total-handle) {
+/* Hide point dots and labels via CSS when the Points toggle is off, then
+   re-show the total slot — its label is the shape's identity anchor, kept
+   visible when Points are toggled off so each shape stays addressable.
+
+   We use override-and-undo (not :not()) because Tailwind v4 / Lightning CSS
+   strips `:not(.total-*)` exclusions when those classes aren't used as
+   selectors elsewhere. The override pattern below survives that pass:
+   the exemption rules use `.total-handle` / `.total-label` as full
+   selectors, which the optimizer keeps. */
+.points-hidden .react-flow__handle {
   width: 1px !important;
   height: 1px !important;
   min-width: 0 !important;
@@ -166,8 +171,18 @@ input[type="search"]::-webkit-search-results-decoration {
   opacity: 0 !important;
   box-shadow: none !important;
 }
-.points-hidden .point-label:not(.total-label) {
+.points-hidden .point-label {
   display: none !important;
+}
+.points-hidden .total-handle {
+  width: 12px !important;
+  height: 12px !important;
+  min-width: 12px !important;
+  min-height: 12px !important;
+  opacity: 1 !important;
+}
+.points-hidden .total-label {
+  display: flex !important;
 }
 
 @keyframes spin {

--- a/components/editor/Canvas.tsx
+++ b/components/editor/Canvas.tsx
@@ -628,6 +628,8 @@ function Canvas() {
         deleteKeyCode={['Delete', 'Backspace']}
         panOnScroll
         zoomOnPinch
+        minZoom={0.05}
+        maxZoom={4}
         proOptions={{ hideAttribution: true }}
         style={{ background: theme.canvas.background }}
       >

--- a/components/editor/geometry.ts
+++ b/components/editor/geometry.ts
@@ -259,7 +259,7 @@ const emptyBody: CanonicalBody = { type: 'circle' }
 const emptyGeometry: ShapeGeometry<'empty'> = {
   body: emptyBody,
   bodyOpacity: 0,
-  nodeSize: () => BASE_SIZE / 4,
+  nodeSize: () => BASE_SIZE / 2,
   pointAnchor: (_p, slot, _sub, _idx, n) => {
     if (slot === 'left')   return { x: 0,     y: n / 2, position: Position.Left   }
     if (slot === 'right')  return { x: n,     y: n / 2, position: Position.Right  }


### PR DESCRIPTION
## Summary

Three small editor fixes from one session:

- **Empty scale 2×** — `emptyGeometry.nodeSize` reverted from `BASE_SIZE/4` to `BASE_SIZE/2`. The shrink made empty carriers too small to read.
- **Totals visible when Points off** — root cause was Tailwind v4 / Lightning CSS silently stripping `:not(.total-handle)`/`:not(.total-label)` from the `.points-hidden` rules because those classes weren't used as standalone selectors elsewhere. Replaced with override-and-undo (hide all, then re-show `.total-handle` + `.total-label`).
- **Wider zoom range** — `minZoom: 0.05`, `maxZoom: 4` (React Flow defaults are 0.5–2). Wide diagrams that span thousands of pixels now fit on screen.

## Test plan

- [ ] Toggle Points off in Kinds menu → total dots + labels stay visible at each shape's NW frame anchor; regular point dots/labels disappear
- [ ] Toggle Points back on → all points + labels return
- [ ] Empty shapes render at the larger size (matches the size before the recent shrink)
- [ ] Scroll-zoom out past the previous floor → can zoom out further (down to 5%)
- [ ] Scroll-zoom in past 200% → can zoom up to 400%

🤖 Generated with [Claude Code](https://claude.com/claude-code)