### PR TITLE
chore: bridge Drizzle migrations to Supabase via /supabase symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 
 # Claude Code playwright-mcp browser automation logs/screenshots (debug output)
 /.playwright-mcp
+
+# Supabase CLI runtime cache under the symlinked supabase/ folder
+/supabase/.temp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,16 +32,38 @@ _concept/02-diagram/schema.nesycat.json   (you edit this)
         ▼  npm run db:diagram
 _concept/03-orm-schema/schema.ts          (generated — DO NOT EDIT)
         │
-        ▼  drizzle-kit generate
+        ▼  npm run db:generate            (drizzle-kit generate)
 _concept/03-orm-schema/migrations/*.sql
         │
-        ▼  drizzle-kit migrate
+        ▼  git push                       (Supabase auto-applies via branching)
 Supabase Postgres
 ```
+
+The pipeline is linear: there is **no** manual `drizzle-kit migrate` step.
+Drizzle's job ends at producing SQL files. Supabase's GitHub integration
+applies those files automatically — to a per-PR preview branch on PR open,
+to the `staging` persistent branch on merge, and to production on promotion
+to `main`. See "Why there's a `supabase/` folder at root" below.
 
 `lib/db/index.ts` (drizzle client + `withRLS()`) and `lib/supabase/*` (auth
 SDK clients + middleware) are the **runtime** glue — they consume what
 `_concept/` defines. Don't move them; don't conflate them with concept.
+
+## Why there's a `supabase/` folder at root
+
+Supabase's GitHub integration auto-applies migrations from
+`<workdir>/supabase/migrations/` and reads config from
+`<workdir>/supabase/config.toml`. Its working dir is `.` (repo root), so it
+looks at the root. Our canonical locations are deeper, per the `_concept/`
+taxonomy:
+
+- migrations: `_concept/03-orm-schema/migrations/` (Drizzle's `out:` target)
+- config:     `_concept/04-data-schema/config.toml`
+
+`supabase/` at root is a real directory containing two symlinks bridging
+both. Drizzle remains the single source of truth for migrations; Supabase
+reads through the bridge. Don't put real files in `supabase/` — only
+symlinks back into `_concept/`.
 
 ## Branch + PR strategy
 
@@ -62,7 +84,9 @@ SDK clients + middleware) are the **runtime** glue — they consume what
 - **Drizzle**: `drizzle.config.ts` lives at `_concept/03-orm-schema/drizzle.config.ts`
   (with the rest of the Drizzle stack). The `db:*` scripts in `package.json`
   pass `--config _concept/03-orm-schema/drizzle.config.ts`. Always invoke them
-  via `npm run db:…` so cwd stays at repo root and `.env.local` resolves.
+  via `npm run db:…` so cwd stays at repo root and `.env.local` resolves. The
+  scripts intentionally don't include a `db:migrate` — Supabase applies
+  migrations on push, not Drizzle.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint",
     "db:diagram": "tsx _concept/03-orm-schema/codegen/diagram-to-drizzle.ts _concept/02-diagram/schema.nesycat.json _concept/03-orm-schema/schema.ts",
     "db:generate": "drizzle-kit generate --config _concept/03-orm-schema/drizzle.config.ts",
-    "db:migrate": "drizzle-kit migrate --config _concept/03-orm-schema/drizzle.config.ts",
     "db:studio": "drizzle-kit studio --config _concept/03-orm-schema/drizzle.config.ts"
   },
   "dependencies": {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,1 @@
+../_concept/04-data-schema/config.toml

--- a/supabase/migrations
+++ b/supabase/migrations
@@ -1,0 +1,1 @@
+../_concept/03-orm-schema/migrations


### PR DESCRIPTION
## Summary

Wires up Supabase's GitHub-integration auto-branching so it sees Drizzle's migrations — without flattening the `_concept/` taxonomy.

- Adds `/supabase` at repo root as a **real directory containing two symlinks** back into `_concept/`:
  - `supabase/config.toml` → `../_concept/04-data-schema/config.toml`
  - `supabase/migrations`  → `../_concept/03-orm-schema/migrations`
- Drizzle's config is unchanged: it still writes to `_concept/03-orm-schema/migrations/`. Supabase reads through the bridge. Drizzle remains the single source of truth.
- **Removes** the `db:migrate` npm script. With auto-branching enabled, Supabase applies migrations on push (preview branch on PR open, staging on merge, main on promotion). A second manual applier would only cause drift between Drizzle's `__drizzle_migrations` table and Supabase's `supabase_migrations.schema_migrations` table. The pipeline is now strictly linear:

  ```
  edit diagram → db:diagram → db:generate → commit → push → Supabase applies
  ```

- `CLAUDE.md` documents the bridge ("Why there's a `supabase/` folder at root") and the linearized flow.
- `.gitignore` now excludes `/supabase/.temp` (Supabase CLI runtime cache).

## One-time baseline (manual, out-of-band before merge)

Migration `0000_thankful_silver_samurai.sql` was already applied to **main** via `npm run db:migrate` previously, but Supabase doesn't know it ran (its `supabase_migrations.schema_migrations` table is empty). Without baselining, the next deploy that runs through Supabase auto-branching would crash trying to re-create `public.diagrams`.

Run before merging:

\`\`\`bash
# main:
npx supabase migration repair --status applied 0000 \\
  --db-url 'postgresql://postgres:<PASSWORD>@db.pgzzbbgxjpaljjjzaomv.supabase.co:5432/postgres'

# staging — only if it actually has the diagrams table; check first:
psql 'postgresql://postgres:<PASSWORD>@db.ldhbnxcpsmdbbttwyzlx.supabase.co:5432/postgres' \\
  -c "SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname='public' AND tablename='diagrams');"

# if true, also baseline staging with the same repair command pointed at staging.
\`\`\`

## Test plan

- [ ] \`ls -la supabase/\` shows two symlinks pointing into \`_concept/\`.
- [ ] \`cat supabase/config.toml\` returns the same content as \`_concept/04-data-schema/config.toml\`.
- [ ] \`ls supabase/migrations/\` lists \`0000_thankful_silver_samurai.sql\` and \`meta/\`.
- [ ] After merge, the staging Supabase branch shows \`0000\` in \`schema_migrations\` exactly once (no re-run, no error).
- [ ] Future PRs touching \`supabase/migrations/\` auto-create a Supabase preview branch with the migration applied cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)