### PR TITLE
chore: declare staging persistent branch in supabase config.toml

### DIFF
--- a/_concept/04-data-schema/config.toml
+++ b/_concept/04-data-schema/config.toml
@@ -404,3 +404,9 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 # declarative_schema_path = "./database"
 # JSON string passed through to pg-delta SQL formatting.
 # format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+
+# Persistent branches must be declared here so any branch-scoped settings in
+# this file (auth, secrets, etc.) get applied to them on deploy. Without this,
+# the GitHub integration emits a Configurations warning on every PR.
+[remotes.staging]
+project_id = "ldhbnxcpsmdbbttwyzlx"


### PR DESCRIPTION
## Summary

Adds \`[remotes.staging]\` to \`_concept/04-data-schema/config.toml\` (which is what \`supabase/config.toml\` symlinks to) so the persistent \`staging\` branch is declared in the Supabase config instead of only existing in the dashboard.

\`\`\`toml
[remotes.staging]
project_id = "ldhbnxcpsmdbbttwyzlx"
\`\`\`

## Why

The Supabase GitHub integration emits a "Configurations" ⚠️ on every PR (see PR #40's bot comment) recommending this declaration. Without it, branch-scoped overrides in \`config.toml\` (\`[auth]\`, secrets, etc.) won't apply to the staging branch on deploy. With it, the warning clears and the config becomes self-documenting.

Once merged, this commit will be picked up by the open release PR (#40) automatically.

## Test plan

- [ ] Bot comment on this PR shows ✅ on Configurations.
- [ ] PR #40 (\`staging → main\`) updates and its bot comment also clears the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)