### PR TITLE
chore: scaffold _design/00-design-system + editor chrome wireframe

### DIFF
--- a/_design/00-design-system/README.md
+++ b/_design/00-design-system/README.md
@@ -1,0 +1,31 @@
+# 00-design-system
+
+The visual primitives the editor is built from — colours, typography, fonts,
+effects, the shape palette — copied here for design-time reference.
+
+Open `index.html` in a browser to see the style guide.
+
+## Source of truth
+
+The app is the canonical home for these tokens:
+
+- `app/globals.css` — `:root { … }` block + `@layer components { .t-* }` typography.
+- `components/editor/style/theme.ts` — typed facade plus TS-only values (node
+  opacities, text shadows, the SVG grid colour).
+- `components/editor/color.ts` — `DEFAULT_COLOR` shape palette.
+- `app/layout.tsx` — Geist Sans / Geist Mono via `next/font/google`.
+
+`tokens.css` here is a **copy**, not a link. When the redesign lands in the
+app, port the changes back into those files and resync this copy.
+
+## Consuming from later phases
+
+Each later phase pulls `tokens.css` with a relative link so the wireframe,
+mockup, and prototype all share the same primitives:
+
+```html
+<link rel="stylesheet" href="../00-design-system/tokens.css" />
+```
+
+Fonts are loaded directly from Google Fonts in each phase's HTML so the
+static pages don't depend on the Next.js runtime.

--- a/_design/00-design-system/index.html
+++ b/_design/00-design-system/index.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>00 — Design System</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@500;600&display=swap" />
+  <link rel="stylesheet" href="./tokens.css" />
+  <style>
+    body {
+      margin: 0;
+      padding: 48px 56px;
+      background: var(--color-canvas-bg);
+      color: var(--color-text-secondary);
+      font-family: var(--font-geist-sans);
+      min-height: 100vh;
+    }
+    .page-header {
+      max-width: 920px;
+      margin: 0 auto 48px;
+    }
+    .page-header p {
+      max-width: 640px;
+      color: var(--color-text-muted);
+    }
+    section {
+      max-width: 920px;
+      margin: 0 auto 56px;
+      padding: 28px;
+      border: 1px solid var(--color-glass-border);
+      border-radius: var(--size-radius-md);
+      background: var(--color-glass-panel-bg);
+      backdrop-filter: blur(var(--effect-blur));
+      -webkit-backdrop-filter: blur(var(--effect-blur));
+    }
+    section > h2 {
+      margin: 0 0 24px;
+    }
+    .grid {
+      display: grid;
+      gap: 16px;
+    }
+    .grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+
+    /* Colour swatch */
+    .swatch {
+      border-radius: var(--size-radius-md);
+      overflow: hidden;
+      border: 1px solid var(--color-glass-border);
+      background: var(--color-glass-button-bg);
+    }
+    .swatch .chip {
+      height: 64px;
+      background-image:
+        linear-gradient(45deg, rgba(255,255,255,0.04) 25%, transparent 25%),
+        linear-gradient(-45deg, rgba(255,255,255,0.04) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, rgba(255,255,255,0.04) 75%),
+        linear-gradient(-45deg, transparent 75%, rgba(255,255,255,0.04) 75%);
+      background-size: 12px 12px;
+      background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+    }
+    .swatch .chip > div {
+      width: 100%;
+      height: 100%;
+    }
+    .swatch .meta {
+      padding: 10px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .swatch .meta .name { color: var(--color-text-primary); font-size: 13px; font-weight: 600; }
+    .swatch .meta .value { font-family: var(--font-geist-mono); font-size: 11px; color: var(--color-text-muted); }
+
+    /* Typography rows */
+    .type-row {
+      display: flex;
+      align-items: baseline;
+      gap: 24px;
+      padding: 14px 0;
+      border-bottom: 1px solid var(--color-glass-border);
+    }
+    .type-row:last-child { border-bottom: none; }
+    .type-row .name {
+      width: 100px;
+      font-family: var(--font-geist-mono);
+      font-size: 11px;
+      color: var(--color-text-muted);
+      flex-shrink: 0;
+    }
+    .type-row .specimen { flex: 1; }
+
+    /* Effects */
+    .effect-card {
+      padding: 20px;
+      border-radius: var(--size-radius-md);
+      border: 1px solid var(--color-glass-border);
+      background: var(--color-glass-panel-bg);
+      backdrop-filter: blur(var(--effect-blur));
+      -webkit-backdrop-filter: blur(var(--effect-blur));
+    }
+    .effect-card .label {
+      font-family: var(--font-geist-mono);
+      font-size: 11px;
+      color: var(--color-text-muted);
+      margin-bottom: 8px;
+    }
+    .effect-card .value {
+      color: var(--color-text-primary);
+      font-size: 14px;
+    }
+
+    /* Shape palette tiers */
+    .shape-tier {
+      height: 60px;
+      border-radius: 6px;
+      border: 1px solid rgba(var(--shape-default-rgb), var(--shape-border-opacity));
+      background: rgba(var(--shape-default-rgb), var(--shape-fill-opacity));
+    }
+    .shape-tier.selected {
+      border-color: rgba(var(--shape-default-rgb), var(--shape-selected-border));
+      background: rgba(var(--shape-default-rgb), var(--shape-selected-fill));
+    }
+    .canvas-sample {
+      height: 120px;
+      border-radius: var(--size-radius-md);
+      background-color: var(--color-canvas-bg);
+      background-image: radial-gradient(var(--canvas-grid-color) 1px, transparent 1px);
+      background-size: 12px 12px;
+      border: 1px solid var(--color-glass-border);
+    }
+
+    footer {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 24px 0;
+      color: var(--color-text-dimmed);
+      font-family: var(--font-geist-mono);
+      font-size: 11px;
+      line-height: 1.6;
+      border-top: 1px solid var(--color-glass-border);
+    }
+    code {
+      font-family: var(--font-geist-mono);
+      color: var(--color-text-secondary);
+      background: var(--color-glass-button-bg);
+      padding: 1px 6px;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+
+<div class="page-header">
+  <div class="t-caption">NeSyCat · Design system · v0</div>
+  <h1 class="t-display">Tokens, typography, palette.</h1>
+  <p class="t-body">
+    The visual primitives the editor is built from. Every token below is
+    sourced from <code>app/globals.css</code>, <code>components/editor/style/theme.ts</code>,
+    and <code>components/editor/color.ts</code>. This page is a static reference;
+    later phases (<code>02-wireframe/</code>, <code>03-mockup/</code>,
+    <code>04-prototype/</code>) consume the same <code>tokens.css</code>.
+  </p>
+</div>
+
+<section>
+  <h2 class="t-h1">Colours</h2>
+
+  <h3 class="t-caption" style="margin: 20px 0 12px">Canvas + glass</h3>
+  <div class="grid grid-cols-4">
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-canvas-bg)"></div></div>
+      <div class="meta"><span class="name">canvas-bg</span><span class="value">#0f0f14</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-glass-panel-bg)"></div></div>
+      <div class="meta"><span class="name">glass-panel-bg</span><span class="value">rgba(15,15,20,0.4)</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-glass-button-bg)"></div></div>
+      <div class="meta"><span class="name">glass-button-bg</span><span class="value">rgba(255,255,255,0.06)</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-glass-border)"></div></div>
+      <div class="meta"><span class="name">glass-border</span><span class="value">rgba(255,255,255,0.08)</span></div>
+    </div>
+  </div>
+
+  <h3 class="t-caption" style="margin: 28px 0 12px">Text</h3>
+  <div class="grid grid-cols-4">
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-text-primary)"></div></div>
+      <div class="meta"><span class="name">text-primary</span><span class="value">#ffffff</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-text-secondary)"></div></div>
+      <div class="meta"><span class="name">text-secondary</span><span class="value">rgba(255,255,255,0.8)</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-text-muted)"></div></div>
+      <div class="meta"><span class="name">text-muted</span><span class="value">rgba(255,255,255,0.55)</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-text-dimmed)"></div></div>
+      <div class="meta"><span class="name">text-dimmed</span><span class="value">rgba(255,255,255,0.35)</span></div>
+    </div>
+  </div>
+
+  <h3 class="t-caption" style="margin: 28px 0 12px">Accent</h3>
+  <div class="grid grid-cols-3">
+    <div class="swatch">
+      <div class="chip"><div style="background: var(--color-accent-blue)"></div></div>
+      <div class="meta"><span class="name">accent-blue</span><span class="value">rgb(59,130,246) · tailwind blue-500</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: rgba(var(--color-accent-rgb), 0.4)"></div></div>
+      <div class="meta"><span class="name">accent / 40%</span><span class="value">rgba(59,130,246,0.4)</span></div>
+    </div>
+    <div class="swatch">
+      <div class="chip"><div style="background: rgba(var(--color-accent-rgb), 0.18)"></div></div>
+      <div class="meta"><span class="name">accent / 18%</span><span class="value">rgba(59,130,246,0.18)</span></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2 class="t-h1">Typography</h2>
+  <p class="t-small" style="margin-top: -8px">
+    All seven utilities below mirror <code>app/globals.css</code>'s <code>@layer components</code> block.
+  </p>
+  <div style="margin-top: 16px">
+    <div class="type-row">
+      <span class="name">.t-display</span>
+      <span class="specimen t-display">Draw string diagrams.</span>
+    </div>
+    <div class="type-row">
+      <span class="name">.t-h1</span>
+      <span class="specimen t-h1">Heading one — section title</span>
+    </div>
+    <div class="type-row">
+      <span class="name">.t-h2</span>
+      <span class="specimen t-h2">Heading two — panel title</span>
+    </div>
+    <div class="type-row">
+      <span class="name">.t-body</span>
+      <span class="specimen t-body">Body copy. Compose shapes, wire their points, round-trip JSON.</span>
+    </div>
+    <div class="type-row">
+      <span class="name">.t-small</span>
+      <span class="specimen t-small">Smaller body. Used for inline hints and supporting copy.</span>
+    </div>
+    <div class="type-row">
+      <span class="name">.t-caption</span>
+      <span class="specimen t-caption">SECTION CAPTION · 11PX UPPERCASE MONO</span>
+    </div>
+    <div class="type-row">
+      <span class="name">.t-mono</span>
+      <span class="specimen t-mono">v0.x · 2026 · JSON-in / JSON-out</span>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2 class="t-h1">Effects + sizing</h2>
+  <div class="grid grid-cols-3">
+    <div class="effect-card">
+      <div class="label">size-radius-md</div>
+      <div class="value">8px</div>
+    </div>
+    <div class="effect-card">
+      <div class="label">effect-blur</div>
+      <div class="value">3px backdrop blur (this card)</div>
+    </div>
+    <div class="effect-card">
+      <div class="label">text-shadow</div>
+      <div class="value" style="text-shadow: var(--text-shadow)">Drop-shadowed text</div>
+    </div>
+  </div>
+
+  <h3 class="t-caption" style="margin: 28px 0 12px">Canvas surface (grid)</h3>
+  <div class="canvas-sample"></div>
+</section>
+
+<section>
+  <h2 class="t-h1">Shape palette</h2>
+  <p class="t-small" style="margin-top: -8px">
+    Each shape in a diagram tints its body and border from the accent colour.
+    Fill / border opacities are constants in <code>components/editor/style/theme.ts</code>
+    (also exposed here as CSS vars for static reuse).
+  </p>
+  <div class="grid grid-cols-4" style="margin-top: 16px">
+    <div>
+      <div class="t-caption" style="margin-bottom: 8px">default</div>
+      <div class="shape-tier"></div>
+      <div class="t-mono" style="margin-top: 6px; color: var(--color-text-muted)">fill 18% · border 35%</div>
+    </div>
+    <div>
+      <div class="t-caption" style="margin-bottom: 8px">selected</div>
+      <div class="shape-tier selected"></div>
+      <div class="t-mono" style="margin-top: 6px; color: var(--color-text-muted)">fill 35% · border 70%</div>
+    </div>
+    <div>
+      <div class="t-caption" style="margin-bottom: 8px">accent / 40%</div>
+      <div style="height: 60px; border-radius: 6px; background: rgba(var(--shape-default-rgb), 0.4); border: 1px solid rgba(var(--shape-default-rgb), 0.7);"></div>
+      <div class="t-mono" style="margin-top: 6px; color: var(--color-text-muted)">point-dot at rest</div>
+    </div>
+    <div>
+      <div class="t-caption" style="margin-bottom: 8px">accent / 100%</div>
+      <div style="height: 60px; border-radius: 6px; background: rgb(var(--shape-default-rgb)); border: 1px solid rgb(var(--shape-default-rgb));"></div>
+      <div class="t-mono" style="margin-top: 6px; color: var(--color-text-muted)">point-dot selected</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  Source of truth: <code>app/globals.css</code> · <code>components/editor/style/theme.ts</code> · <code>components/editor/color.ts</code> · <code>app/layout.tsx</code> (fonts).
+  <br />
+  Update them when the redesign is applied; resync <code>tokens.css</code> after.
+</footer>
+
+</body>
+</html>

--- a/_design/00-design-system/tokens.css
+++ b/_design/00-design-system/tokens.css
@@ -1,0 +1,100 @@
+/*
+ * NeSyCat design tokens — copied from the app for design-time reference.
+ *
+ * Source of truth lives at:
+ *   app/globals.css                          (`:root { ... }` + `@layer components { .t-* }`)
+ *   components/editor/style/theme.ts         (typed facade + TS-only values)
+ *   components/editor/color.ts               (`DEFAULT_COLOR` shape palette)
+ *   app/layout.tsx                           (Geist fonts via `next/font/google`)
+ *
+ * When the design phase produces a final redesign, port the changes back into
+ * the app's source-of-truth files and keep this file in sync.
+ */
+
+:root {
+  /* Canvas + glass-morphism */
+  --color-canvas-bg:       #0f0f14;
+  --color-glass-panel-bg:  rgba(15, 15, 20, 0.4);
+  --color-glass-button-bg: rgba(255, 255, 255, 0.06);
+  --color-glass-border:    rgba(255, 255, 255, 0.08);
+
+  /* Text hierarchy */
+  --color-text-primary:    #ffffff;
+  --color-text-secondary:  rgba(255, 255, 255, 0.8);
+  --color-text-muted:      rgba(255, 255, 255, 0.55);
+  --color-text-dimmed:     rgba(255, 255, 255, 0.35);
+
+  /* Accent */
+  --color-accent-blue:     rgb(59, 130, 246);
+  --color-accent-rgb:      59, 130, 246;
+
+  /* Size + effect */
+  --size-radius-md:        8px;
+  --effect-blur:           3px;
+
+  /* Shape palette (matches color.ts DEFAULT_COLOR). The opacity tiers below
+     are TS-only constants in components/editor/style/theme.ts; exposing them
+     here as CSS vars so design-time HTML can reference them. */
+  --shape-default-rgb:        59, 130, 246;
+  --shape-fill-opacity:       0.18;
+  --shape-border-opacity:     0.35;
+  --shape-selected-fill:      0.35;
+  --shape-selected-border:    0.7;
+
+  /* Canvas-only values pulled from theme.ts (SVG grid + text shadows) */
+  --canvas-grid-color:        rgba(255, 255, 255, 0.03);
+  --text-shadow:              0 1px 3px rgba(0, 0, 0, 0.5);
+  --text-shadow-light:        0 1px 2px rgba(0, 0, 0, 0.3);
+
+  /* Font families */
+  --font-geist-sans: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-geist-mono: "Geist Mono", "SF Mono", Menlo, ui-monospace, monospace;
+}
+
+/* Typography utilities — verbatim copy of @layer components from globals.css. */
+
+.t-display {
+  font-size: 48px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  color: var(--color-text-primary);
+}
+.t-h1 {
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+}
+.t-h2 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-text-primary);
+}
+.t-body {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+.t-small {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+.t-caption {
+  font-family: var(--font-geist-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.t-mono {
+  font-family: var(--font-geist-mono);
+  font-size: 14px;
+  font-weight: 500;
+}

--- a/_design/00-design-system/tokens.css
+++ b/_design/00-design-system/tokens.css
@@ -98,3 +98,24 @@
   font-size: 14px;
   font-weight: 500;
 }
+
+/* Thin glass scrollbar (verbatim from app/globals.css). Applies everywhere
+   so any overflowing pane — sidebar list, JSON panel, design-system style
+   guide — uses the same look as the editor. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
+}
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+::-webkit-scrollbar-corner { background: transparent; }

--- a/_design/02-wireframe/README.md
+++ b/_design/02-wireframe/README.md
@@ -7,38 +7,46 @@ Flow canvas). Open `index.html` in a browser to view.
 
 The shell around the canvas:
 
-- Left sidebar — Shape-spine tool rail. 56-wide vertical strip with the
-  logo on top and one icon button per editable field of `Shape<K>` from
-  `components/editor/types.ts` (`name`, `points`,
-  `kind`, `order`, `color`, `transform`, `equations`, `weight`). File
-  management (search, diagram list, +new) is no longer in the sidebar.
-- Top-right JSON panel (closed and open states).
-- Bottom-left zoom controls (built-in React Flow `<Controls />`).
-- Star-prompt modal (idle-triggered overlay).
+- **Top bar** — 52 px horizontal strip with the logo on the left, one
+  shape-tool button per editable field of `Shape<K>` from
+  `components/editor/types.ts` (`name`, `points`, `kind`, `order`,
+  `color`, `transform`, `equations`, `weight`) centered, and a share
+  control on the right. File management (search, diagram list, +new)
+  is not in the wireframe — it'll live in a separate picker.
+- **Diagram-data panel** opened by the share control (top-right of the
+  canvas), reusing the `.tool-popover` shell.
+- **Bottom-left zoom controls** (built-in React Flow `<Controls />`).
+- **Star-prompt modal** (idle-triggered overlay).
 
-Each is rendered as a separate "scene" so we can iterate on regions
-independently and capture multiple states. The rail is fixed — no
-collapsed-sidebar variant.
+Each scene is one 1728×1080 frame; we iterate on regions
+independently and capture multiple states.
 
 | # | Scene | What it shows |
 |---|---|---|
-| 1 | default state | baseline editor with the icon rail |
-| 5 | `name` popover | rename input + visibility footer |
-| 6 | `points` popover | hint + visibility footer (no editor) |
-| 7 | `kind` popover | five rectangular kind tiles (full `ShapeKind`) + visibility footer |
-| 8 | `order` popover | Fresco-style vertical slider + visibility footer |
-| 9 | `color` popover | full HSV + sliders + swatches + visibility footer |
-| 10 | `transform` popover | tx/ty/θ/sx/sy grid + visibility footer |
-| 11 | `equations` popover | equations list + add + visibility footer |
-| 12 | `weight` popover | continuous slider + visibility footer |
-| 13 | JSON panel | top-right glass panel + Export / Import |
+| 1 | default state | baseline editor with the topbar |
+| 5 | `name` popover | rename input + visibility dot in the head |
+| 6 | `points` popover | header only — visibility dot (no editor) |
+| 7 | `kind` popover | one column per `ShapeKind` — per-kind visibility dot + drag tile |
+| 8 | `order` popover | Fresco-style discrete slider + numeric input |
+| 9 | `color` popover | HSV ring + S/V field + corner presets + HSB/α + swatches |
+| 10 | `transform` popover | Scale / Translate / Rotate rows |
+| 11 | `equations` popover | list + `+` add in the head |
+| 12 | `weight` popover | continuous slider, numeric field above the track |
+| 13 | diagram-data panel | top-right `.tool-popover` with Export / Import + JSON |
 | 14 | star-prompt modal | idle-triggered overlay |
 
-Each tool popover follows the same shape: **header (property label) → editor
-body → 3-state visibility footer** (`Off · Selected · All`). The
-visibility footer is parked at the bottom so the editor stays in the
-visual foreground (aligned with the segmented control pattern used for
-canvas visibility in <code>Canvas.tsx</code>).
+Every shape-tool popover shares the same `.tool-popover` shell: a
+`.head` (caption + visibility dot, optionally `.actions`) and a `.body`.
+The visibility dot is binary (`.head-vis-toggle.is-on` / not) — clicking
+toggles whether the slot's visualisation is drawn on the canvas. Scene 7
+adds a column-level dot per `ShapeKind` so individual kinds can be
+hidden without affecting the others.
+
+Popover horizontal positioning is parametric: each instance carries
+`style="--tool-index: <0..7>"` and the stylesheet resolves
+`left = --shape-cluster-start + index × --shape-tool-stride`. Moving
+the topbar geometry edits two CSS vars on `.editor-frame`, not eight
+inline pixel values.
 
 The right margin of Scene 1 carries an annotation column with redesign-hook
 notes — concrete observations about the current layout that the next

--- a/_design/02-wireframe/README.md
+++ b/_design/02-wireframe/README.md
@@ -1,5 +1,41 @@
 # 02-wireframe
 
-HTML + CSS structure only. Layout, regions, hierarchy — no visual fidelity.
+Low-fidelity wireframe of the editor's UI chrome (everything around the React
+Flow canvas). Open `index.html` in a browser to view.
 
-Open `index.html` in a browser to view the current wireframe.
+## What's in scope
+
+The shell around the canvas:
+
+- Left sidebar (logo, search, diagrams list, collapse toggle).
+- Top-left floating toolbar ("Kinds ▾" dropdown + "Straight | Smooth" toggle).
+- Top-right JSON panel (closed and open states).
+- Bottom-left zoom controls (built-in React Flow `<Controls />`).
+- Star-prompt modal (idle-triggered overlay).
+
+Each is rendered as a separate "scene" so we can iterate on regions
+independently and capture multiple states (Scene 1 default, Scene 2 Kinds
+menu open, Scene 3 JSON panel open, Scene 4 star modal).
+
+The right margin of Scene 1 carries an annotation column with redesign-hook
+notes — concrete observations about the current layout that the next
+iteration should address.
+
+## What's out of scope
+
+- The React Flow canvas itself — shapes, points, wires, the JSON spine
+  rendering. Drawn as a labelled placeholder.
+- Inline node UI inside the canvas (double-click rename, slot `+` buttons).
+- Anything below the `app/` layer (data model, mutations, RLS).
+
+## Editing
+
+Plain HTML + CSS, no build step. Edit `index.html` and `styles.css` by hand.
+Tokens come from `../00-design-system/tokens.css` via `@import` in
+`styles.css`, so colours and typography stay consistent with the app
+automatically.
+
+## Output
+
+When iteration converges, hand `index.html` to the `03-mockup/` phase to pin
+visual fidelity, then `04-prototype/` for interactivity.

--- a/_design/02-wireframe/README.md
+++ b/_design/02-wireframe/README.md
@@ -14,8 +14,9 @@ The shell around the canvas:
 - Star-prompt modal (idle-triggered overlay).
 
 Each is rendered as a separate "scene" so we can iterate on regions
-independently and capture multiple states (Scene 1 default, Scene 2 Kinds
-menu open, Scene 3 JSON panel open, Scene 4 star modal).
+independently and capture multiple states (Scene 1 default, Scene 2 sidebar
+collapsed, Scene 3 Kinds menu open, Scene 4 JSON panel open, Scene 5 star
+modal).
 
 The right margin of Scene 1 carries an annotation column with redesign-hook
 notes — concrete observations about the current layout that the next

--- a/_design/02-wireframe/README.md
+++ b/_design/02-wireframe/README.md
@@ -18,9 +18,29 @@ The shell around the canvas:
 - Star-prompt modal (idle-triggered overlay).
 
 Each is rendered as a separate "scene" so we can iterate on regions
-independently and capture multiple states (Scene 1 default, Scene 2 sidebar
-collapsed, Scene 3 Kinds menu open, Scene 4 JSON panel open, Scene 5 star
-modal).
+independently and capture multiple states. The rail is fixed — no
+collapsed-sidebar variant.
+
+| # | Scene | What it shows |
+|---|---|---|
+| 1 | default state | baseline editor with the icon rail |
+| 5 | `name` popover | rename input + visibility footer |
+| 6 | `points` popover | hint + visibility footer (no editor) |
+| 7 | `kind` popover | 5-shape picker + visibility footer |
+| 8 | `order` popover | Fresco-style vertical slider + visibility footer |
+| 9 | `color` popover | full HSV + sliders + swatches + visibility footer |
+| 10 | `transform` popover | tx/ty/θ/sx/sy grid + visibility footer |
+| 11 | `equations` popover | equations list + add + visibility footer |
+| 12 | `weight` popover | continuous slider + visibility footer |
+| 13 | Kinds menu | legacy top-left dropdown (binary on/off toggles) |
+| 14 | JSON panel | top-right glass panel + Export / Import |
+| 15 | star-prompt modal | idle-triggered overlay |
+
+Each tool popover follows the same shape: **header (slot name) → editor
+body → 3-state visibility footer** (`Off · Selected · All`). The
+visibility footer is parked at the bottom so the editor stays in the
+visual foreground; it generalises the binary on/off toggles in the
+legacy Kinds menu (Scene 13).
 
 The right margin of Scene 1 carries an annotation column with redesign-hook
 notes — concrete observations about the current layout that the next

--- a/_design/02-wireframe/README.md
+++ b/_design/02-wireframe/README.md
@@ -8,11 +8,10 @@ Flow canvas). Open `index.html` in a browser to view.
 The shell around the canvas:
 
 - Left sidebar — Shape-spine tool rail. 56-wide vertical strip with the
-  logo on top and one icon button per user-facing slot of `Shape<K>` from
-  `components/editor/types.ts` (slots −1 through 6 — `name`, `points`,
+  logo on top and one icon button per editable field of `Shape<K>` from
+  `components/editor/types.ts` (`name`, `points`,
   `kind`, `order`, `color`, `transform`, `equations`, `weight`). File
   management (search, diagram list, +new) is no longer in the sidebar.
-- Top-left floating toolbar ("Kinds ▾" dropdown + "Straight | Smooth" toggle).
 - Top-right JSON panel (closed and open states).
 - Bottom-left zoom controls (built-in React Flow `<Controls />`).
 - Star-prompt modal (idle-triggered overlay).
@@ -26,21 +25,20 @@ collapsed-sidebar variant.
 | 1 | default state | baseline editor with the icon rail |
 | 5 | `name` popover | rename input + visibility footer |
 | 6 | `points` popover | hint + visibility footer (no editor) |
-| 7 | `kind` popover | 5-shape picker + visibility footer |
+| 7 | `kind` popover | five rectangular kind tiles (full `ShapeKind`) + visibility footer |
 | 8 | `order` popover | Fresco-style vertical slider + visibility footer |
 | 9 | `color` popover | full HSV + sliders + swatches + visibility footer |
 | 10 | `transform` popover | tx/ty/θ/sx/sy grid + visibility footer |
 | 11 | `equations` popover | equations list + add + visibility footer |
 | 12 | `weight` popover | continuous slider + visibility footer |
-| 13 | Kinds menu | legacy top-left dropdown (binary on/off toggles) |
-| 14 | JSON panel | top-right glass panel + Export / Import |
-| 15 | star-prompt modal | idle-triggered overlay |
+| 13 | JSON panel | top-right glass panel + Export / Import |
+| 14 | star-prompt modal | idle-triggered overlay |
 
-Each tool popover follows the same shape: **header (slot name) → editor
+Each tool popover follows the same shape: **header (property label) → editor
 body → 3-state visibility footer** (`Off · Selected · All`). The
 visibility footer is parked at the bottom so the editor stays in the
-visual foreground; it generalises the binary on/off toggles in the
-legacy Kinds menu (Scene 13).
+visual foreground (aligned with the segmented control pattern used for
+canvas visibility in <code>Canvas.tsx</code>).
 
 The right margin of Scene 1 carries an annotation column with redesign-hook
 notes — concrete observations about the current layout that the next
@@ -50,7 +48,7 @@ iteration should address.
 
 - The React Flow canvas itself — shapes, points, wires, the JSON spine
   rendering. Drawn as a labelled placeholder.
-- Inline node UI inside the canvas (double-click rename, slot `+` buttons).
+- Inline node UI inside the canvas (double-click rename, canvas `+` buttons).
 - Anything below the `app/` layer (data model, mutations, RLS).
 
 ## Editing

--- a/_design/02-wireframe/README.md
+++ b/_design/02-wireframe/README.md
@@ -7,7 +7,11 @@ Flow canvas). Open `index.html` in a browser to view.
 
 The shell around the canvas:
 
-- Left sidebar (logo, search, diagrams list, collapse toggle).
+- Left sidebar — Shape-spine tool rail. 56-wide vertical strip with the
+  logo on top and one icon button per user-facing slot of `Shape<K>` from
+  `components/editor/types.ts` (slots −1 through 6 — `name`, `points`,
+  `kind`, `order`, `color`, `transform`, `equations`, `weight`). File
+  management (search, diagram list, +new) is no longer in the sidebar.
 - Top-left floating toolbar ("Kinds ▾" dropdown + "Straight | Smooth" toggle).
 - Top-right JSON panel (closed and open states).
 - Bottom-left zoom controls (built-in React Flow `<Controls />`).

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -149,10 +149,12 @@
 
     <!-- Top bar — logo + shape tools + share -->
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" title="Back to landing" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"       type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"     type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -184,7 +186,7 @@
 
   <div class="annotations">
     <h3>Top bar — Shape spine (<code>components/editor/types.ts</code>)</h3>
-    <div class="note"><span class="pin">A</span>52 px–tall bar: logo 40×40, then eight 40×40 tools with 6 px gaps, share control flush right.</div>
+    <div class="note"><span class="pin">A</span>52 px–tall bar: logo 40×40 left, eight 40×40 tools centered as a group (6 px gaps), share flush right.</div>
     <div class="note"><span class="pin">B</span><code>name</code> — user-visible label.</div>
     <div class="note"><span class="pin">C</span><code>points</code> — recursive sub-shapes (<code>ShapePoints[K]</code>).</div>
     <div class="note"><span class="pin">D</span><code>kind</code> — <code>ShapeKind</code> discriminator — empty / triangle / rhombus / circle / rectangle.</div>
@@ -224,10 +226,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name is-active" type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -254,8 +258,8 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the name button (i=0, top 60). -->
-      <div class="tool-popover" style="left: 60px; width: 280px">
+      <!-- Popover anchored to the name button (cluster left + i×46). -->
+      <div class="tool-popover" style="left: 683px; width: 280px">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
@@ -294,10 +298,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points is-active" type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -324,8 +330,8 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the points button (i=1, top 106). -->
-      <div class="tool-popover tool-popover--tight" style="left: 106px">
+      <!-- Popover anchored to the points button. -->
+      <div class="tool-popover tool-popover--tight" style="left: 729px">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
@@ -365,10 +371,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"           type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -395,26 +403,25 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the kind button (i=2, top 152).
+      <!-- Popover anchored to the kind button (i=2).
            ShapeKind = keyof ShapePoints → exactly empty | triangle | rhombus | circle | rectangle (types.ts:38-70).
            Line<K> extends Shape<K> and uses the same kind field — not a sixth ShapeKind (types.ts:137-148).
-           Layout: one row per ShapeKind. Left = decorative visibility dot (wireframe); only the drag tile on the right is interactive.
-           Header strip: panel-level visibility dot; rows keep per-kind visibility. -->
-      <div class="tool-popover" style="left: 152px; width: max-content; min-width: 0">
+           Layout: one horizontal strip — one column per ShapeKind (visibility dot above drag tile).
+           Header strip: panel-level visibility toggle; each column has the same toggle chrome per kind. -->
+      <div class="tool-popover" style="left: 775px; width: max-content; min-width: 0">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Panel visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Kind</span>
         </div>
-        <div class="body">
-          <div class="kind-rows" role="group" aria-label="Shape kind">
+        <div class="body kind-rows" role="group" aria-label="Shape kind">
 
             <div class="kind-row">
               <div class="kind-row-left">
-                <span class="kind-vis-toggle is-on" aria-hidden="true">
-                  <span class="kind-vis-dot" aria-hidden="true"></span>
-                </span>
+                <button type="button" class="head-vis-toggle is-on" aria-label="Visibility · empty" aria-pressed="true">
+                  <span class="head-vis-dot" aria-hidden="true"></span>
+                </button>
               </div>
               <button class="drag-tile" type="button" draggable="true"
                       title="empty — drag to canvas · create: 2×">
@@ -424,9 +431,9 @@
 
             <div class="kind-row is-active">
               <div class="kind-row-left">
-                <span class="kind-vis-toggle is-on" aria-hidden="true">
-                  <span class="kind-vis-dot" aria-hidden="true"></span>
-                </span>
+                <button type="button" class="head-vis-toggle is-on" aria-label="Visibility · triangle" aria-pressed="true">
+                  <span class="head-vis-dot" aria-hidden="true"></span>
+                </button>
               </div>
               <button class="drag-tile" type="button" draggable="true"
                       title="triangle — drag to canvas · create: Alt/⌥ + 2×">
@@ -436,9 +443,9 @@
 
             <div class="kind-row">
               <div class="kind-row-left">
-                <span class="kind-vis-toggle is-on" aria-hidden="true">
-                  <span class="kind-vis-dot" aria-hidden="true"></span>
-                </span>
+                <button type="button" class="head-vis-toggle is-on" aria-label="Visibility · rhombus" aria-pressed="true">
+                  <span class="head-vis-dot" aria-hidden="true"></span>
+                </button>
               </div>
               <button class="drag-tile" type="button" draggable="true"
                       title="rhombus — drag to canvas · create: ⇧ + 2×">
@@ -448,9 +455,9 @@
 
             <div class="kind-row">
               <div class="kind-row-left">
-                <span class="kind-vis-toggle is-on" aria-hidden="true">
-                  <span class="kind-vis-dot" aria-hidden="true"></span>
-                </span>
+                <button type="button" class="head-vis-toggle is-on" aria-label="Visibility · circle" aria-pressed="true">
+                  <span class="head-vis-dot" aria-hidden="true"></span>
+                </button>
               </div>
               <button class="drag-tile" type="button" draggable="true"
                       title="circle — drag to canvas · create: Space + 2×">
@@ -460,9 +467,9 @@
 
             <div class="kind-row">
               <div class="kind-row-left">
-                <span class="kind-vis-toggle is-on" aria-hidden="true">
-                  <span class="kind-vis-dot" aria-hidden="true"></span>
-                </span>
+                <button type="button" class="head-vis-toggle is-on" aria-label="Visibility · rectangle" aria-pressed="true">
+                  <span class="head-vis-dot" aria-hidden="true"></span>
+                </button>
               </div>
               <button class="drag-tile" type="button" draggable="true"
                       title="rectangle — drag to canvas · create: Ctrl/⌘ + 2×">
@@ -470,7 +477,6 @@
               </button>
             </div>
 
-          </div>
         </div>
       </div>
     </div>
@@ -479,7 +485,7 @@
   <div class="annotations">
     <h3>Source of truth</h3>
     <div class="note"><span class="pin">A</span><code>Shape.kind: K</code> at <code>types.ts:120</code>; <code>ShapeKind = keyof ShapePoints</code> at <code>types.ts:70</code> — exactly the five rows. <code>Line</code> extends <code>Shape&lt;K&gt;</code> (<code>types.ts:143-146</code>) and uses the same <code>kind</code>; diagram edges are not a sixth discriminator.</div>
-    <div class="note"><span class="pin">B</span>Each row: decorative per-kind visibility dot (left); only the <strong>drag tile</strong> is interactive — drag to the canvas to create a node of that kind.</div>
+    <div class="note"><span class="pin">B</span>Each column: per-kind visibility toggle (<code>head-vis-toggle</code>, same chrome as the panel header); drag tile creates that kind on the canvas.</div>
     <div class="note"><span class="pin">C</span>Today: no kind-change mutation in <code>mutations.ts</code>; kind is only set at <code>addNode()</code> creation time. Drag-to-create is the primary affordance.</div>
   </div>
 </section>
@@ -500,10 +506,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -531,7 +539,7 @@
       </div>
 
       <!-- Popover anchored to the order button (i=3, top 198). -->
-      <div class="tool-popover" style="left: 198px; width: 280px">
+      <div class="tool-popover" style="left: 821px; width: 280px">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
@@ -572,10 +580,11 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 9 — color popover</h2>
   <p class="lead">
-    The <code>color</code> popover is a full HSV picker — annular hue ring
-    + inner S/V square, HSB sliders, alpha track, swatches grid. Mirrors
-    the layout of Adobe Fresco's "Color" panel. Today there's no picker;
-    shapes initialise to <code>DEFAULT_COLOR = [59/255, 130/255, 246/255]</code>
+    The <code>color</code> popover is a full HSV picker — smooth annular hue ring
+    (conic spectrum), inner S/V square, four corner actions (white / black /
+    eyedropper / transparency), opacity under the wheel, HSB sliders, and
+    swatches. Mirrors the Adobe Fresco Color panel layout. Today there's no picker.
+    Shapes initialise to <code>DEFAULT_COLOR = [59/255, 130/255, 246/255]</code>
     from <code>color.ts:5</code> and never change.
   </p>
 
@@ -583,10 +592,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -614,7 +625,7 @@
       </div>
 
       <!-- Popover anchored to the color button (i=4, top 244). -->
-      <div class="tool-popover" style="left: 244px; width: 280px">
+      <div class="tool-popover tool-popover--color" style="left: 867px; width: 296px">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
@@ -622,38 +633,33 @@
           <span class="head-title">Color</span>
         </div>
         <div class="body">
-          <div class="color-wheel" aria-label="HSV wheel">
-            <div class="color-current" title="Current color"></div>
-            <svg viewBox="0 0 220 220" width="220" height="220">
-              <defs>
-                <linearGradient id="cw-sv-h" x1="0" y1="0" x2="1" y2="0">
-                  <stop offset="0" stop-color="#fff"/>
-                  <stop offset="1" stop-color="rgb(59,130,246)"/>
-                </linearGradient>
-                <linearGradient id="cw-sv-v" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0" stop-color="rgba(0,0,0,0)"/>
-                  <stop offset="1" stop-color="#000"/>
-                </linearGradient>
-              </defs>
-              <!-- hue ring (rough; 8-stop conic via dashed segments) -->
-              <g fill="none" stroke-width="22">
-                <circle cx="110" cy="110" r="92" stroke="#f00" stroke-dasharray="72 506"  stroke-dashoffset="0"/>
-                <circle cx="110" cy="110" r="92" stroke="#ff0" stroke-dasharray="72 506"  stroke-dashoffset="-72"/>
-                <circle cx="110" cy="110" r="92" stroke="#0f0" stroke-dasharray="72 506"  stroke-dashoffset="-144"/>
-                <circle cx="110" cy="110" r="92" stroke="#0ff" stroke-dasharray="72 506"  stroke-dashoffset="-216"/>
-                <circle cx="110" cy="110" r="92" stroke="#00f" stroke-dasharray="72 506"  stroke-dashoffset="-288"/>
-                <circle cx="110" cy="110" r="92" stroke="#f0f" stroke-dasharray="72 506"  stroke-dashoffset="-360"/>
-                <circle cx="110" cy="110" r="92" stroke="#f00" stroke-dasharray="72 506"  stroke-dashoffset="-432"/>
-              </g>
-              <!-- S/V square inside the ring -->
-              <rect x="60" y="60" width="100" height="100" fill="url(#cw-sv-h)"/>
-              <rect x="60" y="60" width="100" height="100" fill="url(#cw-sv-v)"/>
-              <!-- markers -->
-              <circle cx="195" cy="110" r="6" fill="none" stroke="#fff" stroke-width="2"/>
-              <circle cx="120" cy="100" r="5" fill="none" stroke="#fff" stroke-width="2"/>
-            </svg>
+          <div class="color-wheel" aria-label="HSV wheel — hue ring and saturation / brightness field">
+            <div class="color-wheel-frame">
+              <button type="button" class="color-corner color-corner--white" title="Pure white" aria-label="Set white"></button>
+              <button type="button" class="color-corner color-corner--black" title="Pure black" aria-label="Set black"></button>
+              <button type="button" class="color-corner color-corner--eyedropper" title="Sample from canvas (pipette)" aria-label="Pipette — sample color">
+                <!-- Lucide “pipette” (MIT): github.com/lucide-icons/lucide -->
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12"/>
+                  <path d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z"/>
+                  <path d="m2 22 .414-.414"/>
+                </svg>
+              </button>
+              <button type="button" class="color-corner color-corner--transparent" title="Transparency" aria-label="Transparency preset"></button>
+              <!-- Smooth spectral ring (CSS conic-gradient + radial mask) -->
+              <div class="color-hue-ring" aria-hidden="true"></div>
+              <div class="color-hue-thumb" aria-hidden="true"></div>
+              <div class="color-sv-field">
+                <div class="color-sv-thumb" aria-hidden="true"></div>
+              </div>
+            </div>
           </div>
           <div class="color-sliders">
+            <div class="slider-row">
+              <span class="row-label">α</span>
+              <div class="h-track alpha"><div class="h-thumb" style="left: 100%"></div></div>
+              <input class="num-input" value="100" title="Opacity %" />
+            </div>
             <div class="slider-row">
               <span class="row-label">H</span>
               <div class="h-track hue"><div class="h-thumb" style="left: 60%"></div></div>
@@ -668,11 +674,6 @@
               <span class="row-label">B</span>
               <div class="h-track val"><div class="h-thumb" style="left: 96%"></div></div>
               <input class="num-input" value="96" />
-            </div>
-            <div class="slider-row">
-              <span class="row-label">α</span>
-              <div class="h-track alpha"><div class="h-thumb" style="left: 100%"></div></div>
-              <input class="num-input" value="100" />
             </div>
           </div>
           <span class="body-label">Swatches</span>
@@ -726,10 +727,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -757,7 +760,7 @@
       </div>
 
       <!-- Popover anchored to the transform button (i=5, top 290). -->
-      <div class="tool-popover" style="left: 290px; width: 296px">
+      <div class="tool-popover" style="left: 913px; width: 296px">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
@@ -765,19 +768,26 @@
           <span class="head-title">Transform</span>
         </div>
         <div class="body">
-          <span class="body-label">Translate</span>
-          <div class="txn-grid">
-            <div class="cell"><span class="row-label">tx</span><input class="num-input" value="120" /></div>
-            <div class="cell"><span class="row-label">ty</span><input class="num-input" value="-40" /></div>
+          <div class="transform-row">
+            <span class="transform-row-name">Scale</span>
+            <div class="transform-row-fields">
+              <div class="transform-field"><span class="transform-field-label">sx</span><input class="num-input" type="text" value="1.00" aria-label="Scale x" /></div>
+              <div class="transform-field"><span class="transform-field-label">sy</span><input class="num-input" type="text" value="1.00" aria-label="Scale y" /></div>
+            </div>
           </div>
-          <span class="body-label">Rotate / scale</span>
-          <div class="txn-grid">
-            <div class="cell"><span class="row-label">θ</span><input class="num-input" value="0°" /></div>
-            <div class="cell"><span class="row-label">sx</span><input class="num-input" value="1.00" /></div>
-            <div class="cell" style="grid-column: 1"><span class="row-label">sy</span><input class="num-input" value="1.00" /></div>
-            <button class="reset-btn" type="button">Reset</button>
+          <div class="transform-row">
+            <span class="transform-row-name">Translate</span>
+            <div class="transform-row-fields">
+              <div class="transform-field"><span class="transform-field-label">tx</span><input class="num-input" type="text" value="120" aria-label="Translate x" /></div>
+              <div class="transform-field"><span class="transform-field-label">ty</span><input class="num-input" type="text" value="-40" aria-label="Translate y" /></div>
+            </div>
           </div>
-          <span class="hint">Drag on canvas to translate. Rotation / scale aren't bound to handles yet.</span>
+          <div class="transform-row">
+            <span class="transform-row-name">Rotate</span>
+            <div class="transform-row-fields">
+              <div class="transform-field"><span class="transform-field-label">θ</span><input class="num-input" type="text" value="0°" aria-label="Rotation" /></div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -807,10 +817,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -838,21 +850,21 @@
       </div>
 
       <!-- Popover anchored to the equations button (i=6, top 336). -->
-      <div class="tool-popover" style="left: 336px; width: 296px">
+      <div class="tool-popover tool-popover--equations" style="left: 959px; width: 352px">
         <div class="head">
           <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Equations</span>
+          <button type="button" class="sidebar-tool eq-popover-add" title="Add equation" aria-label="Add equation">
+            <svg><use href="#ic-plus"/></svg>
+          </button>
         </div>
         <div class="body">
-          <span class="body-label">this = …</span>
           <div class="eq-list">
             <div class="eq-row"><span>x + y</span><span class="delete">×</span></div>
             <div class="eq-row"><span>2 · z − w</span><span class="delete">×</span></div>
           </div>
-          <button class="eq-add" type="button">+ Add equation</button>
-          <span class="hint">Encoding: strings are shape refs, numbers literals, objects ops (<code>+ − * /</code>). Grammar at <code>types.ts:99-100</code>.</span>
         </div>
       </div>
     </div>
@@ -882,10 +894,12 @@
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"           type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -913,7 +927,7 @@
       </div>
 
       <!-- Popover anchored to the weight button (i=7, top 382). -->
-      <div class="tool-popover" style="left: 382px; width: 280px">
+      <div class="tool-popover" style="left: 1005px; width: 280px">
         <div class="head">
           <button type="button" class="head-vis-toggle" aria-label="Visibility" aria-pressed="false">
             <span class="head-vis-dot" aria-hidden="true"></span>
@@ -921,25 +935,21 @@
           <span class="head-title">Weight</span>
         </div>
         <div class="body">
-          <div style="display:flex; align-items:center; gap:12px; justify-content:space-between;">
-            <span class="body-label">Mass</span>
-            <input class="num-input" type="text" value="1.0" aria-label="Weight value" />
-          </div>
-          <div class="slider-col">
-            <div class="slider-stack">
-              <div class="slider-track">
-                <div class="slider-thumb" style="top: 80%"></div>
+          <div class="slider-col slider-col--weight">
+            <div class="weight-slider-controls">
+              <div class="weight-num-row">
+                <input class="num-input" type="text" value="1.0" aria-label="Weight value" />
+              </div>
+              <div class="slider-stack">
+                <div class="slider-track">
+                  <div class="slider-thumb" style="top: 80%"></div>
+                </div>
               </div>
             </div>
-            <div class="slider-notches" aria-hidden="true">
-              <span>5</span><span>4</span><span>3</span><span>2</span><span>1</span><span>0</span>
-            </div>
-            <div class="preview-col">
-              <div class="preview-disk" style="width: 48px; height: 48px"></div>
-              <span class="hint" style="text-align:center;">weight = 1.0<br/>(continuous)</span>
+            <div class="preview-col preview-col--weight-square">
+              <div class="preview-disk"></div>
             </div>
           </div>
-          <span class="hint">Drag the slider or type a 1-decimal value; preview scales with mass.</span>
         </div>
       </div>
     </div>
@@ -958,20 +968,24 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 13 — diagram data panel open</h2>
   <p class="lead">
-    The share control in the top bar opens diagram data — a 400-wide,
-    500-max-height glass panel below it on the right. Header strip
-    carries &quot;Diagram Data&quot; plus Export / Import. Body is the JSON
-    <code>pre</code> at <code>rgba(0,0,0,0.25)</code> background.
+    The share control opens diagram data as the same floating
+    <code>tool-popover</code> chrome as the shape inspector (head + body),
+    anchored top-right inside the canvas (<code>top: 8px; right: 12px</code>),
+    <code>400</code>×<code>max-height: 500</code>. Export / Import live in
+    <code>.head .actions</code>; the JSON payload is a
+    <code>&lt;pre&gt;</code> inside <code>.body</code>.
   </p>
 
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
     <header class="editor-topbar">
-      <div class="topbar-toolbar">
+      <div class="topbar-leading">
         <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
+      </div>
+      <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
           <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
           <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
@@ -992,16 +1006,16 @@
 
     <div class="canvas-area">
 
-      <div class="json-panel-anchor">
-        <div class="json-panel">
-          <div class="header">
-            <span class="label">Diagram Data</span>
-            <div class="actions">
-              <button type="button">Export</button>
-              <button type="button">Import</button>
-            </div>
+      <div class="tool-popover" style="top: 8px; right: 12px; left: auto; width: 400px; max-height: 500px">
+        <div class="head">
+          <span class="head-title">Diagram Data</span>
+          <div class="actions">
+            <button type="button">Export</button>
+            <button type="button">Import</button>
           </div>
-          <pre class="body">{
+        </div>
+        <div class="body">
+          <pre>{
   "schemaVersion": 1,
   "nodes": [
     {
@@ -1054,10 +1068,10 @@
 
   <div class="annotations">
     <h3>Panel (<code>Canvas.tsx</code> 680–710)</h3>
-    <div class="note"><span class="pin">P</span>Width 400, max-height 500, glass panel + 8 px radius. Header strip border-bottom glass-border.</div>
-    <div class="note"><span class="pin">Q</span>Caption: "DIAGRAM DATA" — 11 px Mono / 600 wt / uppercase / muted, 0.05em letter-spacing.</div>
-    <div class="note"><span class="pin">R</span>Export / Import: glass buttons, 4 px radius, 11 px / 2×10 padding. Import opens a hidden file input.</div>
-    <div class="note"><span class="pin">S</span>Body <code>&lt;pre&gt;</code>: <code>rgba(0,0,0,0.25)</code> bg, 12 px padding, 10 px Mono, line-height 1.4, scrollable.</div>
+    <div class="note"><span class="pin">P</span>Same <code>.tool-popover</code> as shape popovers; instance <code>style</code> sets width 400 and max-height 500.</div>
+    <div class="note"><span class="pin">Q</span>Caption uses <code>.head-title</code> (shared with Weight, etc.).</div>
+    <div class="note"><span class="pin">R</span>Export / Import: <code>.head .actions button</code> — light text buttons, shared rule with all diagram-data popovers.</div>
+    <div class="note"><span class="pin">S</span>JSON: <code>.body &gt; pre</code> — mono 10px, scroll; no separate panel bg (inherits <code>--color-glass-panel-bg</code>).</div>
   </div>
 </section>
 

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -42,37 +42,44 @@
       <path d="M8 11V7a4 4 0 1 1 8 0v4"
             stroke="currentColor" stroke-width="2" fill="none" />
     </symbol>
+    <!-- Share / export — upload-from-tray (wireframe; evokes iOS share sheet) -->
+    <symbol id="ic-share" viewBox="0 0 24 24">
+      <path d="M12 4v10M8 8l4-4 4 4" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M5 14v5a2 2 0 002 2h10a2 2 0 002-2v-5" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round"/>
+    </symbol>
 
     <!--
-      Shape-spine tool-rail icons. Each maps 1:1 to a slot of `Shape<K>` in
-      components/editor/types.ts (lines 116-126). viewBox is 24×24 so the
+      Shape-spine tool-rail icons. Each maps 1:1 to a user-facing field of
+      `Shape<K>` in components/editor/types.ts (lines 116-126). viewBox is 24×24 so the
       rail's 18×18 rendering keeps a 3 px optical inset on each side.
     -->
-    <!-- (-1) name — Geist “A”; fill/font on <text> so &lt;use&gt; shadow tree still paints (CSS won’t target cloned nodes). -->
+    <!-- name — Geist “A”; fill/font on <text> so &lt;use&gt; shadow tree still paints (CSS won’t target cloned nodes). -->
     <symbol id="ic-name" viewBox="0 0 24 24">
       <text x="12" y="12" text-anchor="middle" dominant-baseline="central"
             fill="currentColor" stroke="none"
             font-family="Geist, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif"
             font-weight="500" font-size="20" letter-spacing="-0.11">A</text>
     </symbol>
-    <!-- (0) points — two filled dots, wider spacing (recursive sub-shapes) -->
+    <!-- points — two filled dots, wider spacing (recursive sub-shapes) -->
     <symbol id="ic-points" viewBox="0 0 24 24">
       <circle cx="6.25" cy="12" r="2.5" />
       <circle cx="17.75" cy="12" r="2.5" />
     </symbol>
-    <!-- (1) kind — apex-up triangle, representative of `ShapeKind` (empty / triangle / rhombus / circle / rectangle) -->
+    <!-- kind — apex-up triangle, representative of `ShapeKind` (empty / triangle / rhombus / circle / rectangle) -->
     <symbol id="ic-kind" viewBox="0 0 24 24">
       <path d="M12 4l8 16H4z" />
     </symbol>
-    <!-- (2) order — three ascending bars, scalar Order -->
+    <!-- order — three ascending bars, scalar Order -->
     <symbol id="ic-order" viewBox="0 0 24 24">
       <path d="M5 19v-4M12 19v-8M19 19v-12" />
     </symbol>
-    <!-- (3) color — filled disk in the shape's current color -->
+    <!-- color — filled disk in the shape's current color -->
     <symbol id="ic-color" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="7" />
     </symbol>
-    <!-- (4) transform — 4-way move arrows (translation/rotation/scale of SpaceTime) -->
+    <!-- transform — 4-way move arrows (translation/rotation/scale of SpaceTime) -->
     <symbol id="ic-transform" viewBox="0 0 24 24">
       <path d="M12 3v18M3 12h18" />
       <path d="M12 3l-2 2.5M12 3l2 2.5" />
@@ -80,22 +87,20 @@
       <path d="M3 12l2.5-2M3 12l2.5 2" />
       <path d="M21 12l-2.5-2M21 12l-2.5 2" />
     </symbol>
-    <!-- (5) equations — equals sign, Expression[] -->
+    <!-- equations — equals sign, Expression[] -->
     <symbol id="ic-equations" viewBox="0 0 24 24">
       <rect x="4" y="9"  width="16" height="2.2" rx="1" />
       <rect x="4" y="14" width="16" height="2.2" rx="1" />
     </symbol>
-    <!-- (6) weight — kettlebell, scalar Mass -->
+    <!-- weight — kettlebell, scalar Mass -->
     <symbol id="ic-weight" viewBox="0 0 24 24">
       <path d="M9 7a3 3 0 1 1 6 0" />
       <path d="M7 9h10l1.6 11H5.4z" />
     </symbol>
 
-    <!-- Kind-picker glyphs (Scene 7): one per ShapeKind in types.ts:38-65.
-         Used inside the kind-picker tiles. -->
-    <symbol id="kind-empty" viewBox="0 0 24 24">
-      <rect x="5" y="5" width="14" height="14" rx="1.5" />
-    </symbol>
+    <!-- Kind-picker glyphs (Scene 7): one tile per ShapeKind key in types.ts ShapePoints (types.ts:38-65). -->
+    <!-- empty: no glyph — reads only from tile label -->
+    <symbol id="kind-empty" viewBox="0 0 24 24"></symbol>
     <symbol id="kind-triangle" viewBox="0 0 24 24">
       <path d="M12 4l8 16H4z" />
     </symbol>
@@ -106,7 +111,8 @@
       <circle cx="12" cy="12" r="8" />
     </symbol>
     <symbol id="kind-rectangle" viewBox="0 0 24 24">
-      <rect x="3" y="7" width="18" height="10" rx="1" />
+      <!-- Square circumscribing kind-circle (r=8 → side 16); sharp corners -->
+      <rect x="4" y="4" width="16" height="16" />
     </symbol>
   </defs>
 </svg>
@@ -116,8 +122,8 @@
   <h1 class="t-h1">Editor chrome — pixel-faithful to today.</h1>
   <p>
     Each scene is a 1728×1080 frame sized for a 16″ MacBook Pro at default
-    scaling. Sidebar widths, panel sizes, button padding, font weights, kind
-    labels, hotkey chips, JSON-panel header copy, and React Flow controls
+    scaling. Sidebar widths, panel sizes, button padding, font weights,
+    JSON-panel header copy, and React Flow controls
     are pulled directly from <code>components/editor/EditorSidebar.tsx</code>
     and <code>components/editor/Canvas.tsx</code>. The React Flow canvas
     itself (shapes, points, wires, JSON spine) is intentionally left as a
@@ -130,53 +136,42 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 1 — default state</h2>
   <p class="lead">
-    Signed-in user has just opened a diagram. Left sidebar is a 56-wide icon
-    rail — one button per user-facing slot of <code>Shape&lt;K&gt;</code>
-    from <code>components/editor/types.ts</code> (slots −1…6). File
-    management (search, diagram list, +new) is no longer in the sidebar;
-    it lives in a separate picker. Top toolbar floats over the canvas with
-    two glass buttons. JSON panel collapsed. Zoom cluster bottom-left,
-    inset from the fixed-width rail (<code>--sidebar-offset</code>).
+    Signed-in user has just opened a diagram. A <strong>top bar</strong> holds
+    the logo, one tool button per exposed <code>Shape&lt;K&gt;</code> field
+    (<code>name</code> through <code>weight</code>), and a share-style control
+    for export / diagram data. The canvas uses the full width below the bar.
+    Zoom cluster stays bottom-left.
   </p>
 
   <div class="editor-frame">
     <!-- Dot-grid canvas background -->
     <div class="canvas-bg"></div>
 
-    <!-- Left sidebar — Shape-spine tool rail -->
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" title="Back to landing" aria-label="NeSyCat Semiotics">
+    <!-- Top bar — logo + shape tools + share -->
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" title="Back to landing" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"       type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"     type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"       type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"      type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color is-active" type="button" aria-label="Color" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"  type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"  type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"     type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"       type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"     type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"       type="button" aria-label="Kind"      title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"      type="button" aria-label="Order"     title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color" type="button" aria-label="Color" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"  type="button" aria-label="Transform" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"  type="button" aria-label="Equations" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"     type="button" aria-label="Weight"    title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <!-- Top-left toolbar -->
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor">
-          <button class="panel-btn" type="button">Kinds</button>
-        </div>
-        <button class="panel-btn" type="button"
-                title="Edge path: straight — click to switch">Straight</button>
-      </div>
-
-      <!-- Top-right JSON button (collapsed) -->
-      <div class="topright">
-        <button class="panel-btn" type="button">JSON</button>
-      </div>
-
       <!-- Bottom-left React Flow controls -->
       <div class="controls-cluster" aria-label="Zoom controls">
         <button type="button" title="Zoom in"><svg><use href="#ic-plus"/></svg></button>
@@ -188,42 +183,39 @@
   </div>
 
   <div class="annotations">
-    <h3>Sidebar — Shape spine (<code>components/editor/types.ts</code>)</h3>
-    <div class="note"><span class="pin">A</span>56 px rail. Logo on top, 22×22, link back to landing.</div>
-    <div class="note"><span class="pin">B</span><code>name</code> slot (−1): user-visible label.</div>
-    <div class="note"><span class="pin">C</span><code>points</code> slot (0): recursive sub-shapes (<code>ShapePoints[K]</code>).</div>
-    <div class="note"><span class="pin">D</span><code>kind</code> slot (1): <code>ShapeKind</code> discriminator — empty / triangle / rhombus / circle / rectangle.</div>
-    <div class="note"><span class="pin">E</span><code>order</code> slot (2): scalar <code>number</code>.</div>
-    <div class="note"><span class="pin">F</span><code>color</code> slot (3): <code>[r, g, b] ∈ [0, 1]³</code>. Glyph fills with the current shape color so the rail doubles as a swatch.</div>
-    <div class="note"><span class="pin">G</span><code>transform</code> slot (4): <code>SpaceTime</code> — translation + rotation + scale (+ created/updated timestamps).</div>
-    <div class="note"><span class="pin">H</span><code>equations</code> slot (5): list of <code>Expression</code>s (rational over shape refs).</div>
-    <div class="note"><span class="pin">I</span><code>weight</code> slot (6): scalar <code>Mass</code>.</div>
-    <div class="note"><span class="pin">J</span>Slot −2 <code>id</code> intentionally absent — <code>types.ts:29</code>: "Auto-generated, unique, internal — never user-facing."</div>
+    <h3>Top bar — Shape spine (<code>components/editor/types.ts</code>)</h3>
+    <div class="note"><span class="pin">A</span>52 px–tall bar: logo 40×40, then eight 40×40 tools with 6 px gaps, share control flush right.</div>
+    <div class="note"><span class="pin">B</span><code>name</code> — user-visible label.</div>
+    <div class="note"><span class="pin">C</span><code>points</code> — recursive sub-shapes (<code>ShapePoints[K]</code>).</div>
+    <div class="note"><span class="pin">D</span><code>kind</code> — <code>ShapeKind</code> discriminator — empty / triangle / rhombus / circle / rectangle.</div>
+    <div class="note"><span class="pin">E</span><code>order</code> — scalar <code>number</code>.</div>
+    <div class="note"><span class="pin">F</span><code>color</code> — <code>[r, g, b] ∈ [0, 1]³</code>. Glyph fills with the current shape color so the rail doubles as a swatch.</div>
+    <div class="note"><span class="pin">G</span><code>transform</code> — <code>SpaceTime</code> — translation + rotation + scale (+ created/updated timestamps).</div>
+    <div class="note"><span class="pin">H</span><code>equations</code> — list of <code>Expression</code>s (rational over shape refs).</div>
+    <div class="note"><span class="pin">I</span><code>weight</code> — scalar <code>Mass</code>.</div>
+    <div class="note"><span class="pin">J</span>The internal-only <code>id</code> field has no rail button — <code>types.ts:29</code>: "Auto-generated, unique, internal — never user-facing."</div>
     <div class="note"><span class="pin">K</span>Buttons 40×40, 6 px radius. Active state tinted with <code>rgba(accent, 0.18)</code> + accent border. Hover swaps to glass-button bg + glass border.</div>
     <h3>Canvas chrome (<code>Canvas.tsx</code>)</h3>
-    <div class="note"><span class="pin">L</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left (rail fixed at 56 px — not collapsible in this wireframe).</div>
-    <div class="note"><span class="pin">N</span>Each button: <code>panelStyle()</code> + 8 px radius + 6×14 padding, 12 px / 600 wt secondary text.</div>
-    <div class="note"><span class="pin">O</span>"Straight" label toggles to "Smooth" when clicked; tooltip carries the current state.</div>
-    <div class="note"><span class="pin">P</span>JSON button — open state in Scene 14 (panel expands below it, button stays visible above).</div>
-    <div class="note"><span class="pin">Q</span>Zoom cluster from React Flow's <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, also tracks sidebar offset.</div>
+    <div class="note"><span class="pin">L</span>Share control in the top bar opens export / diagram data (panel open in Scene 13). Zoom controls bottom-left.</div>
+    <div class="note"><span class="pin">P</span>Share control; open state in Scene 13 (diagram-data panel drops below the bar on the right).</div>
+    <div class="note"><span class="pin">Q</span>Zoom cluster from React Flow <code>&lt;Controls/&gt;</code>: 28 px buttons stacked.</div>
 
     <h3>Redesign hooks</h3>
     <div class="note">File management (search, diagram list, +new) needs a new home — likely a separate picker / file-tree surface, opened via the logo or a dedicated chrome button.</div>
-    <div class="note">"Kinds ▾" in the top-left toolbar becomes redundant with the rail's <code>kind</code> button — consider merging into the slot-1 dropdown.</div>
-    <div class="note">Color slot's button doubles as the current-color swatch. Click to open a picker; the swatch updates in place.</div>
-    <div class="note">Rail order intentionally follows the slot indices (−1 → 6) in <code>types.ts</code> so it reads as the Shape's own field order.</div>
+    <div class="note">Color control doubles as the current-color swatch. Click to open a picker; the swatch updates in place.</div>
+    <div class="note">Rail order intentionally follows <code>Shape</code> field order in <code>types.ts</code>.</div>
   </div>
 </section>
 
-<!-- ═══════ Scene 5: name popover (slot -1) ═══════ -->
+<!-- ═══════ Scene 5: name popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 5 — name popover</h2>
   <p class="lead">
-    Clicking the <code>name</code> button opens a popover anchored to the
-    right of the rail at the button's y. Header strip names the slot, body
-    holds the editor, and a thin "visibility" footer parks the 3-state
-    "Off · Selected · All" toggle. Rename today happens inline (double-click
+    Clicking the <code>name</code> button opens a popover below the top bar,
+    aligned with that tool. The header row carries the panel
+    title and the 3-state visibility icons (Off · Selected · All); the body
+    holds the editor. Rename today happens inline (double-click
     on the canvas, <code>DiagramNode.tsx:360-448</code>); the input here is
     a faster alternative when the shape is already selected.
   </p>
@@ -231,30 +223,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name is-active" type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"         type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"           type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"          type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"          type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"      type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"      type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"         type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name is-active" type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"           type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"          type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"          type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"      type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"      type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"         type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -263,20 +255,15 @@
       </div>
 
       <!-- Popover anchored to the name button (i=0, top 60). -->
-      <div class="tool-popover" style="top: 60px; width: 280px">
-        <div class="head">name · slot −1</div>
-        <div class="body">
-          <span class="body-label">Rename selected</span>
-          <input class="text-input" type="text" value="Y" />
-          <span class="hint">Or double-click a name on the canvas to edit inline.</span>
+      <div class="tool-popover" style="left: 60px; width: 280px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Name</span>
         </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg" type="button">Selected</button>
-            <button class="seg is-on" type="button">All</button>
-          </div>
+        <div class="body">
+          <input class="text-input" type="text" value="Y" />
         </div>
       </div>
     </div>
@@ -290,7 +277,7 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 6: points popover (slot 0) ═══════ -->
+<!-- ═══════ Scene 6: points popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 6 — points popover</h2>
@@ -306,30 +293,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"             type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points is-active" type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"             type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"            type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"            type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"        type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"        type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"           type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points is-active" type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"             type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"            type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"            type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"        type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"        type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"           type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -338,23 +325,12 @@
       </div>
 
       <!-- Popover anchored to the points button (i=1, top 106). -->
-      <div class="tool-popover" style="top: 106px; width: 280px">
-        <div class="head">points · slot 0</div>
-        <div class="body">
-          <span class="hint">
-            Add points via the <strong>+</strong> buttons that surface on
-            a selected shape. The set of slots offered is schema-driven
-            (<code>enumerateAddable()</code> reads <code>ShapePoints[K]</code>
-            from <code>types.ts:38-65</code>).
-          </span>
-        </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg is-on" type="button">Selected</button>
-            <button class="seg" type="button">All</button>
-          </div>
+      <div class="tool-popover tool-popover--tight" style="left: 106px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Points</span>
         </div>
       </div>
     </div>
@@ -362,52 +338,56 @@
 
   <div class="annotations">
     <h3>Source of truth</h3>
-    <div class="note"><span class="pin">A</span><code>Shape.points: ShapePoints[K]</code> at <code>types.ts:119</code> — recursive sub-shape tree, slot cardinalities per <code>ShapeKind</code>.</div>
+    <div class="note"><span class="pin">A</span><code>Shape.points: ShapePoints[K]</code> at <code>types.ts:119</code> — recursive sub-shape tree; branching shape differs per <code>ShapeKind</code>.</div>
     <div class="note"><span class="pin">B</span>Today: <code>visibility.points</code> in <code>store.ts:8</code>; CSS gate <code>.points-hidden .point-label</code> in <code>app/globals.css</code>.</div>
     <div class="note"><span class="pin">C</span>"Selected" is the new middle step — shows handles only on the active shape.</div>
   </div>
 </section>
 
-<!-- ═══════ Scene 7: kind popover (slot 1) ═══════ -->
+<!-- ═══════ Scene 7: kind popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 7 — kind popover</h2>
   <p class="lead">
-    The <code>kind</code> popover picks one of the five <code>ShapeKind</code>s
-    from <code>types.ts:38-65</code>: <code>empty</code>, <code>triangle</code>,
-    <code>rhombus</code>, <code>circle</code>, <code>rectangle</code>. Today
-    the kind is fixed at creation — this introduces a new mutation
-    ("change kind of selected") that <code>mutations.ts</code> doesn't have
-    yet. Tile glyphs match the <code>geometryRegistry</code> registry order.
+    The <code>kind</code> popover switches among the <strong>five</strong>
+    <code>ShapeKind</code> keys of <code>ShapePoints</code> in
+    <code>types.ts:38-65</code> — <code>empty</code>, <code>triangle</code>,
+    <code>rhombus</code>, <code>circle</code>, <code>rectangle</code>. That is
+    the complete set of shape discriminators for nodes; <code>Line</code>
+    (<code>types.ts:137-146</code>) still carries the same <code>kind</code>
+    field — wires are not a separate kind enum. Today shape kind is fixed at
+    creation; this panel assumes a future mutation. Rectangular tiles match the
+    rail; double-click create shortcuts from <code>geometry.ts</code> live in
+    each tile’s tooltip.
   </p>
 
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"           type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"         type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind is-active" type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"          type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"          type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"      type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"      type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"         type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"           type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind is-active" type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"          type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"          type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"      type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"      type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"         type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -415,40 +395,81 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the kind button (i=2, top 152). -->
-      <div class="tool-popover" style="top: 152px; width: 296px">
-        <div class="head">kind · slot 1</div>
-        <div class="body">
-          <span class="body-label">Change kind of selected</span>
-          <div class="kind-picker">
-            <button class="tile" type="button" title="empty">
-              <svg><use href="#kind-empty"/></svg>
-              <span class="tile-label">empty</span>
-            </button>
-            <button class="tile is-on" type="button" title="triangle">
-              <svg><use href="#kind-triangle"/></svg>
-              <span class="tile-label">triangle</span>
-            </button>
-            <button class="tile" type="button" title="rhombus">
-              <svg><use href="#kind-rhombus"/></svg>
-              <span class="tile-label">rhombus</span>
-            </button>
-            <button class="tile" type="button" title="circle">
-              <svg><use href="#kind-circle"/></svg>
-              <span class="tile-label">circle</span>
-            </button>
-            <button class="tile" type="button" title="rectangle">
-              <svg><use href="#kind-rectangle"/></svg>
-              <span class="tile-label">rect</span>
-            </button>
-          </div>
+      <!-- Popover anchored to the kind button (i=2, top 152).
+           ShapeKind = keyof ShapePoints → exactly empty | triangle | rhombus | circle | rectangle (types.ts:38-70).
+           Line<K> extends Shape<K> and uses the same kind field — not a sixth ShapeKind (types.ts:137-148).
+           Layout: one row per ShapeKind. Left = decorative visibility dot (wireframe); only the drag tile on the right is interactive.
+           Header strip: panel-level visibility dot; rows keep per-kind visibility. -->
+      <div class="tool-popover" style="left: 152px; width: max-content; min-width: 0">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Panel visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Kind</span>
         </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg" type="button">Selected</button>
-            <button class="seg is-on" type="button">All</button>
+        <div class="body">
+          <div class="kind-rows" role="group" aria-label="Shape kind">
+
+            <div class="kind-row">
+              <div class="kind-row-left">
+                <span class="kind-vis-toggle is-on" aria-hidden="true">
+                  <span class="kind-vis-dot" aria-hidden="true"></span>
+                </span>
+              </div>
+              <button class="drag-tile" type="button" draggable="true"
+                      title="empty — drag to canvas · create: 2×">
+                <svg><use href="#kind-empty"/></svg>
+              </button>
+            </div>
+
+            <div class="kind-row is-active">
+              <div class="kind-row-left">
+                <span class="kind-vis-toggle is-on" aria-hidden="true">
+                  <span class="kind-vis-dot" aria-hidden="true"></span>
+                </span>
+              </div>
+              <button class="drag-tile" type="button" draggable="true"
+                      title="triangle — drag to canvas · create: Alt/⌥ + 2×">
+                <svg><use href="#kind-triangle"/></svg>
+              </button>
+            </div>
+
+            <div class="kind-row">
+              <div class="kind-row-left">
+                <span class="kind-vis-toggle is-on" aria-hidden="true">
+                  <span class="kind-vis-dot" aria-hidden="true"></span>
+                </span>
+              </div>
+              <button class="drag-tile" type="button" draggable="true"
+                      title="rhombus — drag to canvas · create: ⇧ + 2×">
+                <svg><use href="#kind-rhombus"/></svg>
+              </button>
+            </div>
+
+            <div class="kind-row">
+              <div class="kind-row-left">
+                <span class="kind-vis-toggle is-on" aria-hidden="true">
+                  <span class="kind-vis-dot" aria-hidden="true"></span>
+                </span>
+              </div>
+              <button class="drag-tile" type="button" draggable="true"
+                      title="circle — drag to canvas · create: Space + 2×">
+                <svg><use href="#kind-circle"/></svg>
+              </button>
+            </div>
+
+            <div class="kind-row">
+              <div class="kind-row-left">
+                <span class="kind-vis-toggle is-on" aria-hidden="true">
+                  <span class="kind-vis-dot" aria-hidden="true"></span>
+                </span>
+              </div>
+              <button class="drag-tile" type="button" draggable="true"
+                      title="rectangle — drag to canvas · create: Ctrl/⌘ + 2×">
+                <svg><use href="#kind-rectangle"/></svg>
+              </button>
+            </div>
+
           </div>
         </div>
       </div>
@@ -457,13 +478,13 @@
 
   <div class="annotations">
     <h3>Source of truth</h3>
-    <div class="note"><span class="pin">A</span><code>Shape.kind: K</code> at <code>types.ts:120</code>; <code>ShapeKind = keyof ShapePoints</code> at <code>types.ts:70</code>.</div>
-    <div class="note"><span class="pin">B</span>Today: no kind-change mutation in <code>mutations.ts</code>; only set at <code>addNode()</code> creation time.</div>
-    <div class="note"><span class="pin">C</span>Tile glyphs match the registry order rendered in the legacy "Kinds" dropdown (Scene 13).</div>
+    <div class="note"><span class="pin">A</span><code>Shape.kind: K</code> at <code>types.ts:120</code>; <code>ShapeKind = keyof ShapePoints</code> at <code>types.ts:70</code> — exactly the five rows. <code>Line</code> extends <code>Shape&lt;K&gt;</code> (<code>types.ts:143-146</code>) and uses the same <code>kind</code>; diagram edges are not a sixth discriminator.</div>
+    <div class="note"><span class="pin">B</span>Each row: decorative per-kind visibility dot (left); only the <strong>drag tile</strong> is interactive — drag to the canvas to create a node of that kind.</div>
+    <div class="note"><span class="pin">C</span>Today: no kind-change mutation in <code>mutations.ts</code>; kind is only set at <code>addNode()</code> creation time. Drag-to-create is the primary affordance.</div>
   </div>
 </section>
 
-<!-- ═══════ Scene 8: order popover (slot 2) ═══════ -->
+<!-- ═══════ Scene 8: order popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 8 — order popover</h2>
@@ -478,30 +499,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"            type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"          type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"            type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order is-active" type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"           type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"       type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"       type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"          type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"            type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order is-active" type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"           type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"       type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"       type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"          type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -510,35 +531,28 @@
       </div>
 
       <!-- Popover anchored to the order button (i=3, top 198). -->
-      <div class="tool-popover" style="top: 198px; width: 280px">
-        <div class="head">order · slot 2</div>
+      <div class="tool-popover" style="left: 198px; width: 280px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Order</span>
+        </div>
         <div class="body">
-          <div style="display:flex; align-items:center; gap:12px; justify-content:space-between;">
-            <span class="body-label">Order</span>
+          <div class="order-value-row">
             <input class="num-input" type="text" value="2" aria-label="Order value" />
-          </div>
-          <div class="slider-col">
-            <div class="slider-stack">
+            <div class="slider-col slider-col--horizontal">
+              <div class="slider-stack">
               <div class="slider-track">
-                <div class="slider-thumb" style="top: 70%"></div>
+                <div class="slider-thumb" aria-hidden="true">
+                  <span class="slider-thumb-dot"></span>
+                </div>
+              </div>
+              </div>
+              <div class="slider-notches" aria-hidden="true">
+                <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span>
               </div>
             </div>
-            <div class="slider-notches" aria-hidden="true">
-              <span>5</span><span>4</span><span>3</span><span>2</span><span>1</span><span>0</span>
-            </div>
-            <div class="preview-col">
-              <div class="preview-disk" style="width: 64px; height: 64px"></div>
-              <span class="hint" style="text-align:center;">order = 2<br/>(discrete steps)</span>
-            </div>
-          </div>
-          <span class="hint">Drag the slider or type a number; the preview scales with the order.</span>
-        </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg is-on" type="button">Selected</button>
-            <button class="seg" type="button">All</button>
           </div>
         </div>
       </div>
@@ -553,7 +567,7 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 9: color popover (slot 3) ═══════ -->
+<!-- ═══════ Scene 9: color popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 9 — color popover</h2>
@@ -568,30 +582,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"            type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"          type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"            type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"           type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color is-active" type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"       type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"       type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"          type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"            type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"           type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color is-active" type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"       type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"       type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"          type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -600,8 +614,13 @@
       </div>
 
       <!-- Popover anchored to the color button (i=4, top 244). -->
-      <div class="tool-popover" style="top: 244px; width: 280px">
-        <div class="head">color · slot 3</div>
+      <div class="tool-popover" style="left: 244px; width: 280px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Color</span>
+        </div>
         <div class="body">
           <div class="color-wheel" aria-label="HSV wheel">
             <div class="color-current" title="Current color"></div>
@@ -678,14 +697,6 @@
             <div class="sw" style="background:#000"></div>
           </div>
         </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg" type="button">Selected</button>
-            <button class="seg is-on" type="button">All</button>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -698,7 +709,7 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 10: transform popover (slot 4) ═══════ -->
+<!-- ═══════ Scene 10: transform popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 10 — transform popover</h2>
@@ -714,30 +725,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"                type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"              type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"                type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"               type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"               type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform is-active" type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"           type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"              type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"                type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"               type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"               type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform is-active" type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"           type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"              type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -746,8 +757,13 @@
       </div>
 
       <!-- Popover anchored to the transform button (i=5, top 290). -->
-      <div class="tool-popover" style="top: 290px; width: 296px">
-        <div class="head">transform · slot 4</div>
+      <div class="tool-popover" style="left: 290px; width: 296px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Transform</span>
+        </div>
         <div class="body">
           <span class="body-label">Translate</span>
           <div class="txn-grid">
@@ -763,14 +779,6 @@
           </div>
           <span class="hint">Drag on canvas to translate. Rotation / scale aren't bound to handles yet.</span>
         </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg is-on" type="button">Selected</button>
-            <button class="seg" type="button">All</button>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -783,7 +791,7 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 11: equations popover (slot 5) ═══════ -->
+<!-- ═══════ Scene 11: equations popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 11 — equations popover</h2>
@@ -798,30 +806,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"                type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"              type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"                type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"               type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"               type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"           type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations is-active" type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"              type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"                type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"               type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"               type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"           type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations is-active" type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"              type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -830,8 +838,13 @@
       </div>
 
       <!-- Popover anchored to the equations button (i=6, top 336). -->
-      <div class="tool-popover" style="top: 336px; width: 296px">
-        <div class="head">equations · slot 5</div>
+      <div class="tool-popover" style="left: 336px; width: 296px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Equations</span>
+        </div>
         <div class="body">
           <span class="body-label">this = …</span>
           <div class="eq-list">
@@ -840,14 +853,6 @@
           </div>
           <button class="eq-add" type="button">+ Add equation</button>
           <span class="hint">Encoding: strings are shape refs, numbers literals, objects ops (<code>+ − * /</code>). Grammar at <code>types.ts:99-100</code>.</span>
-        </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg" type="button">Off</button>
-            <button class="seg is-on" type="button">Selected</button>
-            <button class="seg" type="button">All</button>
-          </div>
         </div>
       </div>
     </div>
@@ -861,7 +866,7 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 12: weight popover (slot 6) ═══════ -->
+<!-- ═══════ Scene 12: weight popover ═══════ -->
 
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 12 — weight popover</h2>
@@ -876,30 +881,30 @@
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"             type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"           type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"             type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"            type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"            type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"        type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"        type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight is-active" type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"           type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"             type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"            type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"            type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"        type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"        type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight is-active" type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
       <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
@@ -908,8 +913,13 @@
       </div>
 
       <!-- Popover anchored to the weight button (i=7, top 382). -->
-      <div class="tool-popover" style="top: 382px; width: 280px">
-        <div class="head">weight · slot 6</div>
+      <div class="tool-popover" style="left: 382px; width: 280px">
+        <div class="head">
+          <button type="button" class="head-vis-toggle" aria-label="Visibility" aria-pressed="false">
+            <span class="head-vis-dot" aria-hidden="true"></span>
+          </button>
+          <span class="head-title">Weight</span>
+        </div>
         <div class="body">
           <div style="display:flex; align-items:center; gap:12px; justify-content:space-between;">
             <span class="body-label">Mass</span>
@@ -931,14 +941,6 @@
           </div>
           <span class="hint">Drag the slider or type a 1-decimal value; preview scales with mass.</span>
         </div>
-        <div class="vis-footer">
-          <span class="footer-label">Visibility</span>
-          <div class="vis-seg" role="radiogroup">
-            <button class="seg is-on" type="button">Off</button>
-            <button class="seg" type="button">Selected</button>
-            <button class="seg" type="button">All</button>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -951,158 +953,46 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 13: Kinds menu open ═══════ -->
+<!-- ═══════ Scene 13: JSON panel open ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 13 — Kinds menu open</h2>
+  <h2 class="t-h1">Scene 13 — diagram data panel open</h2>
   <p class="lead">
-    Hovering the "Kinds" button reveals a glass dropdown 6 px below it.
-    Eight rows: five per-kind toggles (in registry order — Empties,
-    Triangles, Rhombuses, Circles, Rectangles) and three orthogonal toggles
-    (Points, Lines, Outlines). Each row is 5×10 padding, 11 px / 500 wt text;
-    on-state colours the dot accent-blue with a 3 px halo and brightens the
-    label to secondary; off rows stay dimmed.
+    The share control in the top bar opens diagram data — a 400-wide,
+    500-max-height glass panel below it on the right. Header strip
+    carries &quot;Diagram Data&quot; plus Export / Import. Body is the JSON
+    <code>pre</code> at <code>rgba(0,0,0,0.25)</code> background.
   </p>
 
   <div class="editor-frame">
     <div class="canvas-bg"></div>
 
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+    <header class="editor-topbar">
+      <div class="topbar-toolbar">
+        <a class="topbar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
-    </aside>
+      <div class="topbar-actions">
+        <button type="button" class="sidebar-tool topbar-share is-panel-open" title="Export or share diagram data" aria-label="Share or export diagram" aria-expanded="true">
+          <svg><use href="#ic-share"/></svg>
+        </button>
+      </div>
+    </header>
 
     <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor">
-          <button class="panel-btn" type="button">Kinds</button>
-          <div class="kinds-menu">
-            <div class="panel">
-              <!-- Per-kind toggles in registry order (Canvas.tsx 651-653). -->
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Empties</span>
-                <span class="kbds"><span class="kbd">2×</span></span>
-              </div>
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Triangles</span>
-                <span class="kbds"><span class="kbd">Alt/⌥</span><span class="kbd">2×</span></span>
-              </div>
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Rhombuses</span>
-                <span class="kbds"><span class="kbd">⇧</span><span class="kbd">2×</span></span>
-              </div>
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Circles</span>
-                <span class="kbds"><span class="kbd">2×</span></span>
-              </div>
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Rectangles</span>
-                <span class="kbds"><span class="kbd">Ctrl/⌘</span><span class="kbd">2×</span></span>
-              </div>
-              <!-- Orthogonal toggles (Canvas.tsx 655-657). -->
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Points</span>
-                <span class="kbds"><span class="kbd">click +</span></span>
-              </div>
-              <div class="kind-row is-on">
-                <span class="dot"></span>
-                <span class="label">Lines</span>
-                <span class="kbds"><span class="kbd">drag ○→○</span></span>
-              </div>
-              <div class="kind-row">
-                <span class="dot"></span>
-                <span class="label">Outlines</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
 
-      <div class="topright">
-        <button class="panel-btn" type="button">JSON</button>
-      </div>
-
-      <div class="controls-cluster">
-        <button type="button"><svg><use href="#ic-plus"/></svg></button>
-        <button type="button"><svg><use href="#ic-minus"/></svg></button>
-        <button type="button"><svg><use href="#ic-fit"/></svg></button>
-        <button type="button"><svg><use href="#ic-lock"/></svg></button>
-      </div>
-    </div>
-  </div>
-
-  <div class="annotations">
-    <h3>Menu structure (<code>Canvas.tsx</code> 646–660)</h3>
-    <div class="note"><span class="pin">K</span>Panel: <code>panelStyle()</code> + 8 px radius, 6×6 padding, <code>minWidth: 220</code>.</div>
-    <div class="note"><span class="pin">L</span>Rows iterate <code>geometryRegistry</code> — adding a kind in <code>types.ts</code> auto-extends this menu.</div>
-    <div class="note"><span class="pin">M</span>Dot: 6×6 circle, accent at 90% with a 3 px halo when on; transparent + 22% border when off.</div>
-    <div class="note"><span class="pin">N</span>Kbd chips: min-width 18, 18 px tall, 1 px glass border, 10 px Mono / 500 wt. Compound shortcuts use two chips side-by-side.</div>
-    <div class="note"><span class="pin">O</span>Outlines off here illustrates the off-state — dimmed label, hollow dot, no kbd hint.</div>
-  </div>
-</section>
-
-<!-- ═══════ Scene 14: JSON panel open ═══════ -->
-
-<section class="wireframe-section">
-  <h2 class="t-h1">Scene 14 — JSON panel open</h2>
-  <p class="lead">
-    JSON button toggles a 400-wide, 500-max-height glass panel. Header strip
-    carries a "DIAGRAM DATA" caption (11 px Mono / 600 wt / uppercase /
-    muted) plus Export / Import buttons. Body renders the diagram JSON in
-    10 px monospace at <code>rgba(0,0,0,0.25)</code> background.
-  </p>
-
-  <div class="editor-frame">
-    <div class="canvas-bg"></div>
-
-    <aside class="sidebar">
-      <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
-          <svg class="logo-mark"><use href="#logo-mark"/></svg>
-        </a>
-        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
-        </div>
-      </div>
-    </aside>
-
-    <div class="canvas-area">
-      <div class="toolbar-topleft">
-        <div class="kinds-anchor">
-          <button class="panel-btn" type="button">Kinds</button>
-        </div>
-        <button class="panel-btn" type="button">Straight</button>
-      </div>
-
-      <div class="topright">
-        <button class="panel-btn" type="button">JSON</button>
+      <div class="json-panel-anchor">
         <div class="json-panel">
           <div class="header">
             <span class="label">Diagram Data</span>
@@ -1171,10 +1061,10 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 15: Star-prompt modal ═══════ -->
+<!-- ═══════ Scene 14: Star-prompt modal ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 15 — Star-prompt modal</h2>
+  <h2 class="t-h1">Scene 14 — Star-prompt modal</h2>
   <p class="lead">
     After ~45 s idle, a full-screen modal asks the user to star the GitHub
     repo. 50% dark scrim over the editor, body centred at ~420 px wide.
@@ -1201,7 +1091,7 @@
 <footer class="wireframe-section" style="border-bottom: none">
   <p class="t-small" style="color: var(--color-text-dimmed)">
     Out of scope: the React Flow canvas itself (node / point / line rendering),
-    the inline rename input on double-clicking a point name, the slot
+    the inline rename input on double-clicking a point name, the canvas
     <code>+</code> buttons that surface when a shape is selected. Those live
     inside the canvas and belong to a separate redesign pass.
   </p>

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -42,11 +42,57 @@
       <path d="M8 11V7a4 4 0 1 1 8 0v4"
             stroke="currentColor" stroke-width="2" fill="none" />
     </symbol>
+
+    <!--
+      Shape-spine tool-rail icons. Each maps 1:1 to a slot of `Shape<K>` in
+      components/editor/types.ts (lines 116-126). viewBox is 24×24 so the
+      rail's 18×18 rendering keeps a 3 px optical inset on each side.
+    -->
+    <!-- (-1) name — pencil -->
+    <symbol id="ic-name" viewBox="0 0 24 24">
+      <path d="M4 20l3-1 11-11-2-2L5 17l-1 3z" />
+      <path d="M14 6l4 4" />
+    </symbol>
+    <!-- (0) points — two filled dots (recursive sub-shapes) -->
+    <symbol id="ic-points" viewBox="0 0 24 24">
+      <circle cx="9"  cy="12" r="2.6" />
+      <circle cx="15" cy="12" r="2.6" />
+    </symbol>
+    <!-- (1) kind — apex-up triangle, representative of `ShapeKind` (empty / triangle / rhombus / circle / rectangle) -->
+    <symbol id="ic-kind" viewBox="0 0 24 24">
+      <path d="M12 4l8 16H4z" />
+    </symbol>
+    <!-- (2) order — three ascending bars, scalar Order -->
+    <symbol id="ic-order" viewBox="0 0 24 24">
+      <path d="M5 19v-4M12 19v-8M19 19v-12" />
+    </symbol>
+    <!-- (3) color — filled disk in the shape's current color -->
+    <symbol id="ic-color" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="7" />
+    </symbol>
+    <!-- (4) transform — 4-way move arrows (translation/rotation/scale of SpaceTime) -->
+    <symbol id="ic-transform" viewBox="0 0 24 24">
+      <path d="M12 3v18M3 12h18" />
+      <path d="M12 3l-2 2.5M12 3l2 2.5" />
+      <path d="M12 21l-2-2.5M12 21l2-2.5" />
+      <path d="M3 12l2.5-2M3 12l2.5 2" />
+      <path d="M21 12l-2.5-2M21 12l-2.5 2" />
+    </symbol>
+    <!-- (5) equations — equals sign, Expression[] -->
+    <symbol id="ic-equations" viewBox="0 0 24 24">
+      <rect x="4" y="9"  width="16" height="2.2" rx="1" />
+      <rect x="4" y="14" width="16" height="2.2" rx="1" />
+    </symbol>
+    <!-- (6) weight — kettlebell, scalar Mass -->
+    <symbol id="ic-weight" viewBox="0 0 24 24">
+      <path d="M9 7a3 3 0 1 1 6 0" />
+      <path d="M7 9h10l1.6 11H5.4z" />
+    </symbol>
   </defs>
 </svg>
 
 <header class="page-header">
-  <div class="t-caption">NeSyCat · Wireframe · v0.2 · 1728×1080 (16″ MBP scaled)</div>
+  <div class="t-caption">NeSyCat · Wireframe · v0.4 · 1728×1080 (16″ MBP scaled)</div>
   <h1 class="t-h1">Editor chrome — pixel-faithful to today.</h1>
   <p>
     Each scene is a 1728×1080 frame sized for a 16″ MacBook Pro at default
@@ -64,38 +110,34 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 1 — default state</h2>
   <p class="lead">
-    Signed-in user has just opened a diagram. Left sidebar 240 px open. Top
-    toolbar floats over the canvas with two glass buttons. JSON panel
-    collapsed. Zoom cluster bottom-left, sliding with the sidebar.
+    Signed-in user has just opened a diagram. Left sidebar is a 56-wide icon
+    rail — one button per user-facing slot of <code>Shape&lt;K&gt;</code>
+    from <code>components/editor/types.ts</code> (slots −1…6). File
+    management (search, diagram list, +new) is no longer in the sidebar;
+    it lives in a separate picker. Top toolbar floats over the canvas with
+    two glass buttons. JSON panel collapsed. Zoom cluster bottom-left,
+    sliding with the sidebar.
   </p>
 
   <div class="editor-frame">
     <!-- Dot-grid canvas background -->
     <div class="canvas-bg"></div>
 
-    <!-- Left sidebar -->
+    <!-- Left sidebar — Shape-spine tool rail -->
     <aside class="sidebar">
       <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#" title="Back to landing">
+        <a class="sidebar-brand" href="#" title="Back to landing" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
-          <span class="brand-name">NeSyCat Semiotics</span>
         </a>
-        <div class="sidebar-search-row">
-          <div class="sidebar-search">
-            <input type="search" placeholder="Search…" aria-label="Search diagrams" />
-          </div>
-          <button class="sidebar-new" type="button" aria-label="New diagram" title="New diagram">+</button>
-        </div>
-        <div class="sidebar-list">
-          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">Alice kills a cat</span><span class="meta">4d ago</span></div>
-          <div class="diagram-row"><span class="title">Human Sysmer</span><span class="meta">6d ago</span></div>
-          <div class="diagram-row"><span class="title">Semiotic Types</span><span class="meta">11d ago</span></div>
-          <div class="diagram-row"><span class="title">Datenbank Vorl. + FK</span><span class="meta">15d ago</span></div>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"       type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"     type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"       type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"      type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color is-active" type="button" aria-label="Color" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"  type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"  type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"     type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
     </aside>
@@ -127,25 +169,32 @@
   </div>
 
   <div class="annotations">
-    <h3>Sidebar (<code>EditorSidebar.tsx</code>)</h3>
-    <div class="note"><span class="pin">A</span>Brand row 14×16 padding, 15 px / 600 wt, border-bottom glass-border.</div>
-    <div class="note"><span class="pin">B</span>Search input 36 px high, 13 px text, glass-border, with clear-button when filled.</div>
-    <div class="note"><span class="pin">C</span><strong>+</strong> button 36×36, glass-border, swaps to spinner while creating.</div>
-    <div class="note"><span class="pin">D</span>Rows 10×16 padding. Active row tinted with <code>rgba(accent, 0.10)</code>. Hover reveals pen + ✕.</div>
-    <div class="note"><span class="pin">E</span><code>‹</code> collapse arrow attached to right edge, slides sidebar to 0 width via <code>--sidebar-offset</code>.</div>
+    <h3>Sidebar — Shape spine (<code>components/editor/types.ts</code>)</h3>
+    <div class="note"><span class="pin">A</span>56 px rail. Logo on top, 22×22, link back to landing.</div>
+    <div class="note"><span class="pin">B</span><code>name</code> slot (−1): user-visible label.</div>
+    <div class="note"><span class="pin">C</span><code>points</code> slot (0): recursive sub-shapes (<code>ShapePoints[K]</code>).</div>
+    <div class="note"><span class="pin">D</span><code>kind</code> slot (1): <code>ShapeKind</code> discriminator — empty / triangle / rhombus / circle / rectangle.</div>
+    <div class="note"><span class="pin">E</span><code>order</code> slot (2): scalar <code>number</code>.</div>
+    <div class="note"><span class="pin">F</span><code>color</code> slot (3): <code>[r, g, b] ∈ [0, 1]³</code>. Glyph fills with the current shape color so the rail doubles as a swatch.</div>
+    <div class="note"><span class="pin">G</span><code>transform</code> slot (4): <code>SpaceTime</code> — translation + rotation + scale (+ created/updated timestamps).</div>
+    <div class="note"><span class="pin">H</span><code>equations</code> slot (5): list of <code>Expression</code>s (rational over shape refs).</div>
+    <div class="note"><span class="pin">I</span><code>weight</code> slot (6): scalar <code>Mass</code>.</div>
+    <div class="note"><span class="pin">J</span>Slot −2 <code>id</code> intentionally absent — <code>types.ts:29</code>: "Auto-generated, unique, internal — never user-facing."</div>
+    <div class="note"><span class="pin">K</span>Buttons 40×40, 6 px radius. Active state tinted with <code>rgba(accent, 0.18)</code> + accent border. Hover swaps to glass-button bg + glass border.</div>
+    <div class="note"><span class="pin">L</span><code>‹</code> collapse handle attached to right edge, slides rail to 0 width via <code>--sidebar-offset</code>.</div>
 
     <h3>Canvas chrome (<code>Canvas.tsx</code>)</h3>
-    <div class="note"><span class="pin">F</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left, slides on collapse with 200 ms transition.</div>
-    <div class="note"><span class="pin">G</span>Each button: <code>panelStyle()</code> + 8 px radius + 6×14 padding, 12 px / 600 wt secondary text.</div>
-    <div class="note"><span class="pin">H</span>"Straight" label toggles to "Smooth" when clicked; tooltip carries the current state.</div>
-    <div class="note"><span class="pin">I</span>JSON button — open state in Scene 4 (panel expands below it, button stays visible above).</div>
-    <div class="note"><span class="pin">J</span>Zoom cluster from React Flow's <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, also tracks sidebar offset.</div>
+    <div class="note"><span class="pin">M</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left, slides on collapse with 200 ms transition.</div>
+    <div class="note"><span class="pin">N</span>Each button: <code>panelStyle()</code> + 8 px radius + 6×14 padding, 12 px / 600 wt secondary text.</div>
+    <div class="note"><span class="pin">O</span>"Straight" label toggles to "Smooth" when clicked; tooltip carries the current state.</div>
+    <div class="note"><span class="pin">P</span>JSON button — open state in Scene 4 (panel expands below it, button stays visible above).</div>
+    <div class="note"><span class="pin">Q</span>Zoom cluster from React Flow's <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, also tracks sidebar offset.</div>
 
     <h3>Redesign hooks</h3>
-    <div class="note">Kinds menu and JSON panel both float over the canvas in opposite corners — could unify under a single right-side dock with tabs.</div>
-    <div class="note">No persistent diagram title / breadcrumb on the canvas — currently only visible in the sidebar row's active state.</div>
-    <div class="note">No user-identity / sign-out surface visible; lives implicitly behind the canvas.</div>
-    <div class="note">Sidebar holds search + list only — could grow to host the Kinds menu, layer toggles, or selection inspector.</div>
+    <div class="note">File management (search, diagram list, +new) needs a new home — likely a separate picker / file-tree surface, opened via the logo or a dedicated chrome button.</div>
+    <div class="note">"Kinds ▾" in the top-left toolbar becomes redundant with the rail's <code>kind</code> button — consider merging into the slot-1 dropdown.</div>
+    <div class="note">Color slot's button doubles as the current-color swatch. Click to open a picker; the swatch updates in place.</div>
+    <div class="note">Rail order intentionally follows the slot indices (−1 → 6) in <code>types.ts</code> so it reads as the Shape's own field order.</div>
   </div>
 </section>
 
@@ -167,18 +216,18 @@
 
     <aside class="sidebar">
       <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
-          <span class="brand-name">NeSyCat Semiotics</span>
         </a>
-        <div class="sidebar-search-row">
-          <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
-          <button class="sidebar-new" type="button">+</button>
-        </div>
-        <div class="sidebar-list">
-          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
     </aside>
@@ -232,20 +281,18 @@
 
     <aside class="sidebar">
       <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
-          <span class="brand-name">NeSyCat Semiotics</span>
         </a>
-        <div class="sidebar-search-row">
-          <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
-          <button class="sidebar-new" type="button">+</button>
-        </div>
-        <div class="sidebar-list">
-          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
     </aside>
@@ -343,20 +390,18 @@
 
     <aside class="sidebar">
       <div class="sidebar-inner">
-        <a class="sidebar-brand" href="#">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
-          <span class="brand-name">NeSyCat Semiotics</span>
         </a>
-        <div class="sidebar-search-row">
-          <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
-          <button class="sidebar-new" type="button">+</button>
-        </div>
-        <div class="sidebar-list">
-          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
-          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
-          <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
     </aside>

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -2,10 +2,330 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>02 — Wireframe</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>02 — Wireframe · Editor chrome</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@500;600&display=swap" />
+  <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <h1>02 — Wireframe</h1>
-  <p>Placeholder. Replace with structural HTML+CSS.</p>
+
+<header class="page-header">
+  <div class="t-caption">NeSyCat · Wireframe · v0</div>
+  <h1 class="t-h1">Editor chrome — current layout.</h1>
+  <p>
+    Low-fidelity wireframe of the editor's UI shell as it ships today. The
+    React Flow canvas in the middle (shapes, points, wires, the JSON spine) is
+    rendered as a labelled placeholder — it's intentionally out of scope.
+    Everything around it is fair game to move, reshape, or replace. Edit the
+    boxes in <code>index.html</code> and <code>styles.css</code> directly to
+    iterate.
+  </p>
+</header>
+
+<!-- ═══════ Scene 1: default editor state ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 1 — default editor state</h2>
+  <p class="lead">
+    Signed-in user has just opened a diagram. Left sidebar expanded, top-left
+    toolbar visible, JSON panel closed in the top-right corner, zoom controls
+    bottom-left.
+  </p>
+
+  <div class="with-annotations">
+    <div class="editor-frame">
+
+      <!-- Left sidebar -->
+      <aside class="sidebar">
+        <div class="sidebar-brand">
+          <span class="logo-mark"></span>
+          <span class="name">NeSyCat</span>
+        </div>
+        <div class="sidebar-search">
+          <input type="text" placeholder="Search…" />
+          <div class="plus">+</div>
+        </div>
+        <div class="sidebar-list">
+          <div class="diagram-row active">
+            <span class="title">Untitled diagram</span>
+            <span class="meta">just now · L1, L2, L3</span>
+          </div>
+          <div class="diagram-row">
+            <span class="title">Categorical layer α</span>
+            <span class="meta">3h ago · 12 pts</span>
+          </div>
+          <div class="diagram-row">
+            <span class="title">Logical 2Mon-BLat</span>
+            <span class="meta">yesterday · 8 pts</span>
+          </div>
+          <div class="diagram-row">
+            <span class="title">Grammar substitution</span>
+            <span class="meta">2 days ago · 4 pts</span>
+          </div>
+          <div class="diagram-row">
+            <span class="title">Binary classification</span>
+            <span class="meta">May 6 · 21 pts</span>
+          </div>
+          <div class="diagram-row">
+            <span class="title">MeasU / GeomU universes</span>
+            <span class="meta">May 5 · 6 pts</span>
+          </div>
+        </div>
+        <div class="sidebar-collapse">‹</div>
+      </aside>
+
+      <!-- Canvas + floating chrome -->
+      <div class="canvas-area">
+
+        <!-- Top-left toolbar -->
+        <div class="glass-bar toolbar-topleft">
+          <button class="glass-btn">Kinds ▾</button>
+          <div class="divider"></div>
+          <div class="toolbar-toggle">
+            <button class="glass-btn is-active">Straight</button>
+            <button class="glass-btn">Smooth</button>
+          </div>
+        </div>
+
+        <!-- Top-right JSON panel (closed) -->
+        <div class="glass-bar json-panel-closed">
+          <button class="glass-btn">JSON</button>
+        </div>
+
+        <!-- Canvas placeholder -->
+        <div class="canvas-placeholder">
+          <div>
+            <strong>React Flow canvas — out of scope.</strong><br />
+            Shapes (rectangle, triangle, circle, rhombus, empty), points,
+            wires, the JSON spine. Rendered unchanged from today; the redesign
+            doesn't touch what's drawn here.
+          </div>
+        </div>
+
+        <!-- Bottom-left zoom controls -->
+        <div class="controls-cluster">
+          <button>+</button>
+          <button>−</button>
+          <button>⊡</button>
+          <button>⤢</button>
+        </div>
+
+      </div>
+    </div>
+
+    <aside class="annotations">
+      <h3>Sidebar</h3>
+      <div class="note"><span class="pin">A</span>Logo + project name. Click → editor home.</div>
+      <div class="note"><span class="pin">B</span>Search filters the diagram list in place.</div>
+      <div class="note"><span class="pin">C</span><strong>+</strong> creates a new untitled diagram and navigates to it.</div>
+      <div class="note"><span class="pin">D</span>Diagram rows: title + relative-time meta. Hover reveals edit/delete.</div>
+      <div class="note"><span class="pin">E</span><code>‹</code> arrow collapses the sidebar to 0 width; toggle re-expands.</div>
+
+      <h3>Canvas chrome</h3>
+      <div class="note"><span class="pin">F</span>Top-left toolbar slides right with the sidebar (CSS var <code>--sidebar-offset</code>).</div>
+      <div class="note"><span class="pin">G</span>"Kinds ▾" on hover/click opens the menu in Scene 2.</div>
+      <div class="note"><span class="pin">H</span>Straight / Smooth toggle controls edge path style.</div>
+      <div class="note"><span class="pin">I</span>JSON button toggles the open-state panel in Scene 3.</div>
+      <div class="note"><span class="pin">J</span>Zoom controls: + / − / fit-view / lock. From React Flow's built-in <code>&lt;Controls /&gt;</code>.</div>
+
+      <h3>Redesign hooks</h3>
+      <div class="note">Floating Kinds menu obscures the top-left of the canvas — could move into the sidebar.</div>
+      <div class="note">JSON panel and Kinds menu share the same surface but live on opposite corners — consider unifying as tabs.</div>
+      <div class="note">No persistent diagram title / breadcrumb on the canvas — currently only visible in the sidebar row.</div>
+      <div class="note">No surface for user identity / sign-out — sits implicitly behind the canvas.</div>
+    </aside>
+  </div>
+</section>
+
+<!-- ═══════ Scene 2: Kinds menu open ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 2 — Kinds menu open</h2>
+  <p class="lead">
+    User hovers the "Kinds ▾" button. Menu drops below the toolbar with one
+    row per shape kind plus orthogonal Points / Lines / Outlines toggles.
+    Hotkey hints in monospace at the right edge of each row.
+  </p>
+
+  <div class="editor-frame">
+    <aside class="sidebar">
+      <div class="sidebar-brand"><span class="logo-mark"></span><span class="name">NeSyCat</span></div>
+      <div class="sidebar-search"><input placeholder="Search…" /><div class="plus">+</div></div>
+      <div class="sidebar-list">
+        <div class="diagram-row active"><span class="title">Untitled diagram</span><span class="meta">just now</span></div>
+        <div class="diagram-row"><span class="title">Categorical layer α</span><span class="meta">3h ago</span></div>
+        <div class="diagram-row"><span class="title">Logical 2Mon-BLat</span><span class="meta">yesterday</span></div>
+        <div class="diagram-row"><span class="title">Grammar substitution</span><span class="meta">2d ago</span></div>
+      </div>
+      <div class="sidebar-collapse">‹</div>
+    </aside>
+    <div class="canvas-area">
+      <div class="glass-bar toolbar-topleft">
+        <button class="glass-btn is-primary">Kinds ▴</button>
+        <div class="divider"></div>
+        <div class="toolbar-toggle">
+          <button class="glass-btn is-active">Straight</button>
+          <button class="glass-btn">Smooth</button>
+        </div>
+      </div>
+
+      <!-- Open Kinds menu -->
+      <div class="kinds-menu">
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Rectangles</span>
+          <span class="hint">⌘ 2×</span>
+        </div>
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Triangles</span>
+          <span class="hint">⌥ 2×</span>
+        </div>
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Rhombuses</span>
+          <span class="hint">⇧ 2×</span>
+        </div>
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Circles</span>
+          <span class="hint">2×</span>
+        </div>
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Empties</span>
+          <span class="hint">⌃ 2×</span>
+        </div>
+        <div class="divider"></div>
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Points</span>
+          <span class="hint">P</span>
+        </div>
+        <div class="row is-toggled">
+          <span class="name"><span class="check on"></span>Lines</span>
+          <span class="hint">L</span>
+        </div>
+        <div class="row">
+          <span class="name"><span class="check"></span>Outlines</span>
+          <span class="hint">O</span>
+        </div>
+      </div>
+
+      <div class="glass-bar json-panel-closed"><button class="glass-btn">JSON</button></div>
+      <div class="canvas-placeholder">
+        <div><strong>React Flow canvas — out of scope.</strong></div>
+      </div>
+      <div class="controls-cluster">
+        <button>+</button><button>−</button><button>⊡</button><button>⤢</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 3: JSON panel open ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 3 — JSON panel open</h2>
+  <p class="lead">
+    User clicked the JSON button. Top-right panel expands to ~320 × 280, with
+    an Export / Import header strip and a read-only code preview of the
+    diagram JSON beneath. Close on click-outside or button toggle.
+  </p>
+
+  <div class="editor-frame">
+    <aside class="sidebar">
+      <div class="sidebar-brand"><span class="logo-mark"></span><span class="name">NeSyCat</span></div>
+      <div class="sidebar-search"><input placeholder="Search…" /><div class="plus">+</div></div>
+      <div class="sidebar-list">
+        <div class="diagram-row active"><span class="title">Untitled diagram</span><span class="meta">just now</span></div>
+        <div class="diagram-row"><span class="title">Categorical layer α</span><span class="meta">3h ago</span></div>
+        <div class="diagram-row"><span class="title">Logical 2Mon-BLat</span><span class="meta">yesterday</span></div>
+      </div>
+      <div class="sidebar-collapse">‹</div>
+    </aside>
+    <div class="canvas-area">
+      <div class="glass-bar toolbar-topleft">
+        <button class="glass-btn">Kinds ▾</button>
+        <div class="divider"></div>
+        <div class="toolbar-toggle">
+          <button class="glass-btn is-active">Straight</button>
+          <button class="glass-btn">Smooth</button>
+        </div>
+      </div>
+
+      <!-- Open JSON panel -->
+      <div class="glass-bar json-panel-open">
+        <div class="header">
+          <div class="left">
+            <button class="glass-btn">JSON ▴</button>
+          </div>
+          <div>
+            <button class="glass-btn">Export ↓</button>
+            <button class="glass-btn">Import ↑</button>
+          </div>
+        </div>
+        <div class="body">{
+  "nodes": [
+    { "id": "S3", "kind": "empty", "points": {
+        "center": { "id": "P4", "name": "Y" }
+    } },
+    { "id": "S4", "kind": "rectangle", "points": {
+        "left":  { "center": [ { "id": "P6", "name": "Y" } ] },
+        "right": { "center": [ { "id": "P7", "name": "H1" } ] }
+    } }
+  ],
+  "edges": [
+    { "id": "L1", "name": "L1", "source": "P4", "targets": ["P6"] },
+    { "id": "L2", "name": "L2", "source": "P7", "targets": ["P8"] }
+  ]
+}</div>
+      </div>
+
+      <div class="canvas-placeholder">
+        <div><strong>React Flow canvas — out of scope.</strong></div>
+      </div>
+      <div class="controls-cluster">
+        <button>+</button><button>−</button><button>⊡</button><button>⤢</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 4: Star-prompt modal ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 4 — Star-prompt modal</h2>
+  <p class="lead">
+    After ~45s idle, a full-screen modal asks the user to star the GitHub
+    repo. Dismissible with "Not now" (snoozes 3 days) or "Star on GitHub"
+    (opens repo). Shown here as a stand-alone state since it overlays any of
+    the scenes above.
+  </p>
+
+  <div class="modal-frame">
+    <div class="modal-scrim">
+      <div class="modal-body">
+        <div class="star">★</div>
+        <h2 class="t-h2" style="margin: 0">Enjoying NeSyCat?</h2>
+        <p class="t-small" style="margin: 0; color: var(--color-text-muted)">
+          A star on GitHub helps other category-theoretic AI folks find the project.
+        </p>
+        <div class="btn-row">
+          <button class="btn">Not now</button>
+          <button class="btn is-primary">Star on GitHub ↗</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer class="wireframe-section" style="border-bottom: none">
+  <p class="t-small" style="color: var(--color-text-dimmed)">
+    Out of scope for this wireframe: the React Flow canvas itself (node /
+    point / line rendering), the inline rename input that appears on
+    double-clicking a point name, the slot <code>+</code> buttons that appear
+    when a shape is selected. Those live inside the canvas and belong to a
+    separate redesign pass.
+  </p>
+</footer>
+
 </body>
 </html>

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -75,56 +75,31 @@
 
     <!-- Left sidebar -->
     <aside class="sidebar">
-      <a class="sidebar-brand" href="#" title="Back to landing">
-        <svg class="logo-mark"><use href="#logo-mark"/></svg>
-        <span class="brand-name">NeSyCat Semiotics</span>
-      </a>
-      <div class="sidebar-search-row">
-        <div class="sidebar-search">
-          <input type="search" placeholder="Search…" aria-label="Search diagrams" />
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" title="Back to landing">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+          <span class="brand-name">NeSyCat Semiotics</span>
+        </a>
+        <div class="sidebar-search-row">
+          <div class="sidebar-search">
+            <input type="search" placeholder="Search…" aria-label="Search diagrams" />
+          </div>
+          <button class="sidebar-new" type="button" aria-label="New diagram" title="New diagram">+</button>
         </div>
-        <button class="sidebar-new" type="button" aria-label="New diagram" title="New diagram">+</button>
-      </div>
-      <div class="sidebar-list">
-        <div class="diagram-row active">
-          <span class="title">Mortimer&apos;s Thesis</span>
-          <span class="meta">2d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">CT for Programmers</span>
-          <span class="meta">2d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">Archetypon Logicon</span>
-          <span class="meta">3d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">PAZ CSG</span>
-          <span class="meta">3d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">PAZ Renderer types.py</span>
-          <span class="meta">3d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">Alice kills a cat</span>
-          <span class="meta">4d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">Human Sysmer</span>
-          <span class="meta">6d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">Semiotic Types</span>
-          <span class="meta">11d ago</span>
-        </div>
-        <div class="diagram-row">
-          <span class="title">Datenbank Vorl. + FK</span>
-          <span class="meta">15d ago</span>
+        <div class="sidebar-list">
+          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">Alice kills a cat</span><span class="meta">4d ago</span></div>
+          <div class="diagram-row"><span class="title">Human Sysmer</span><span class="meta">6d ago</span></div>
+          <div class="diagram-row"><span class="title">Semiotic Types</span><span class="meta">11d ago</span></div>
+          <div class="diagram-row"><span class="title">Datenbank Vorl. + FK</span><span class="meta">15d ago</span></div>
         </div>
       </div>
-      <div class="sidebar-collapse">‹</div>
     </aside>
+    <button class="sidebar-handle" type="button" aria-label="Collapse sidebar" title="Collapse sidebar">‹</button>
 
     <div class="canvas-area">
       <!-- Top-left toolbar -->
@@ -163,7 +138,7 @@
     <div class="note"><span class="pin">F</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left, slides on collapse with 200 ms transition.</div>
     <div class="note"><span class="pin">G</span>Each button: <code>panelStyle()</code> + 8 px radius + 6×14 padding, 12 px / 600 wt secondary text.</div>
     <div class="note"><span class="pin">H</span>"Straight" label toggles to "Smooth" when clicked; tooltip carries the current state.</div>
-    <div class="note"><span class="pin">I</span>JSON button — open state in Scene 3 (panel expands below it, button stays visible above).</div>
+    <div class="note"><span class="pin">I</span>JSON button — open state in Scene 4 (panel expands below it, button stays visible above).</div>
     <div class="note"><span class="pin">J</span>Zoom cluster from React Flow's <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, also tracks sidebar offset.</div>
 
     <h3>Redesign hooks</h3>
@@ -174,10 +149,75 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 2: Kinds menu open ═══════ -->
+<!-- ═══════ Scene 2: Sidebar collapsed ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 2 — Kinds menu open</h2>
+  <h2 class="t-h1">Scene 2 — sidebar collapsed</h2>
+  <p class="lead">
+    Click the handle and the sidebar slides to 0 width (200 ms transition,
+    matches <code>EditorSidebar.tsx</code> setting <code>--sidebar-offset</code>
+    to <code>0px</code>). The handle stays anchored — its <code>left</code>
+    now resolves to 0 — so the user always has an obvious affordance to
+    re-open. The top-left toolbar and the bottom-left zoom cluster slide
+    along with it; the JSON button in the top-right is unaffected.
+  </p>
+
+  <div class="editor-frame is-sidebar-closed">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+          <span class="brand-name">NeSyCat Semiotics</span>
+        </a>
+        <div class="sidebar-search-row">
+          <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
+          <button class="sidebar-new" type="button">+</button>
+        </div>
+        <div class="sidebar-list">
+          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+        </div>
+      </div>
+    </aside>
+    <button class="sidebar-handle" type="button" aria-label="Open sidebar">›</button>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor">
+          <button class="panel-btn" type="button">Kinds</button>
+        </div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+
+      <div class="topright">
+        <button class="panel-btn" type="button">JSON</button>
+      </div>
+
+      <div class="controls-cluster" aria-label="Zoom controls">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Handle</h3>
+    <div class="note"><span class="pin">T</span>Single button, 28×64, glass panel with no left border so it visually attaches to the sidebar or canvas edge.</div>
+    <div class="note"><span class="pin">U</span>Arrow flips from <code>‹</code> (open → close) to <code>›</code> (closed → open) to match the action it triggers.</div>
+    <div class="note"><span class="pin">V</span><code>left: var(--sidebar-offset)</code> with a 200 ms transition — the handle slides in lockstep with the sidebar.</div>
+    <div class="note"><span class="pin">W</span>The whole sidebar (brand row, search, list) is still mounted under the hood — width 0 + <code>overflow: hidden</code> hides it without unmounting state.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 3: Kinds menu open ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 3 — Kinds menu open</h2>
   <p class="lead">
     Hovering the "Kinds" button reveals a glass dropdown 6 px below it.
     Eight rows: five per-kind toggles (in registry order — Empties,
@@ -191,23 +231,25 @@
     <div class="canvas-bg"></div>
 
     <aside class="sidebar">
-      <a class="sidebar-brand" href="#">
-        <svg class="logo-mark"><use href="#logo-mark"/></svg>
-        <span class="brand-name">NeSyCat Semiotics</span>
-      </a>
-      <div class="sidebar-search-row">
-        <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
-        <button class="sidebar-new" type="button">+</button>
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+          <span class="brand-name">NeSyCat Semiotics</span>
+        </a>
+        <div class="sidebar-search-row">
+          <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
+          <button class="sidebar-new" type="button">+</button>
+        </div>
+        <div class="sidebar-list">
+          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
+        </div>
       </div>
-      <div class="sidebar-list">
-        <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
-        <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
-        <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
-        <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
-        <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
-      </div>
-      <div class="sidebar-collapse">‹</div>
     </aside>
+    <button class="sidebar-handle" type="button" aria-label="Collapse sidebar">‹</button>
 
     <div class="canvas-area">
       <div class="toolbar-topleft">
@@ -285,10 +327,10 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 3: JSON panel open ═══════ -->
+<!-- ═══════ Scene 4: JSON panel open ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 3 — JSON panel open</h2>
+  <h2 class="t-h1">Scene 4 — JSON panel open</h2>
   <p class="lead">
     JSON button toggles a 400-wide, 500-max-height glass panel. Header strip
     carries a "DIAGRAM DATA" caption (11 px Mono / 600 wt / uppercase /
@@ -300,23 +342,25 @@
     <div class="canvas-bg"></div>
 
     <aside class="sidebar">
-      <a class="sidebar-brand" href="#">
-        <svg class="logo-mark"><use href="#logo-mark"/></svg>
-        <span class="brand-name">NeSyCat Semiotics</span>
-      </a>
-      <div class="sidebar-search-row">
-        <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
-        <button class="sidebar-new" type="button">+</button>
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+          <span class="brand-name">NeSyCat Semiotics</span>
+        </a>
+        <div class="sidebar-search-row">
+          <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
+          <button class="sidebar-new" type="button">+</button>
+        </div>
+        <div class="sidebar-list">
+          <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
+          <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
+          <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
+        </div>
       </div>
-      <div class="sidebar-list">
-        <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
-        <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
-        <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
-        <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
-        <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
-      </div>
-      <div class="sidebar-collapse">‹</div>
     </aside>
+    <button class="sidebar-handle" type="button" aria-label="Collapse sidebar">‹</button>
 
     <div class="canvas-area">
       <div class="toolbar-topleft">
@@ -396,10 +440,10 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 4: Star-prompt modal ═══════ -->
+<!-- ═══════ Scene 5: Star-prompt modal ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 4 — Star-prompt modal</h2>
+  <h2 class="t-h1">Scene 5 — Star-prompt modal</h2>
   <p class="lead">
     After ~45 s idle, a full-screen modal asks the user to star the GitHub
     repo. 50% dark scrim over the editor, body centred at ~420 px wide.

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -48,15 +48,17 @@
       components/editor/types.ts (lines 116-126). viewBox is 24×24 so the
       rail's 18×18 rendering keeps a 3 px optical inset on each side.
     -->
-    <!-- (-1) name — pencil -->
+    <!-- (-1) name — Geist “A”; fill/font on <text> so &lt;use&gt; shadow tree still paints (CSS won’t target cloned nodes). -->
     <symbol id="ic-name" viewBox="0 0 24 24">
-      <path d="M4 20l3-1 11-11-2-2L5 17l-1 3z" />
-      <path d="M14 6l4 4" />
+      <text x="12" y="12" text-anchor="middle" dominant-baseline="central"
+            fill="currentColor" stroke="none"
+            font-family="Geist, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif"
+            font-weight="500" font-size="20" letter-spacing="-0.11">A</text>
     </symbol>
-    <!-- (0) points — two filled dots (recursive sub-shapes) -->
+    <!-- (0) points — two filled dots, wider spacing (recursive sub-shapes) -->
     <symbol id="ic-points" viewBox="0 0 24 24">
-      <circle cx="9"  cy="12" r="2.6" />
-      <circle cx="15" cy="12" r="2.6" />
+      <circle cx="6.25" cy="12" r="2.5" />
+      <circle cx="17.75" cy="12" r="2.5" />
     </symbol>
     <!-- (1) kind — apex-up triangle, representative of `ShapeKind` (empty / triangle / rhombus / circle / rectangle) -->
     <symbol id="ic-kind" viewBox="0 0 24 24">
@@ -88,11 +90,29 @@
       <path d="M9 7a3 3 0 1 1 6 0" />
       <path d="M7 9h10l1.6 11H5.4z" />
     </symbol>
+
+    <!-- Kind-picker glyphs (Scene 7): one per ShapeKind in types.ts:38-65.
+         Used inside the kind-picker tiles. -->
+    <symbol id="kind-empty" viewBox="0 0 24 24">
+      <rect x="5" y="5" width="14" height="14" rx="1.5" />
+    </symbol>
+    <symbol id="kind-triangle" viewBox="0 0 24 24">
+      <path d="M12 4l8 16H4z" />
+    </symbol>
+    <symbol id="kind-rhombus" viewBox="0 0 24 24">
+      <path d="M12 3l9 9-9 9-9-9z" />
+    </symbol>
+    <symbol id="kind-circle" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="8" />
+    </symbol>
+    <symbol id="kind-rectangle" viewBox="0 0 24 24">
+      <rect x="3" y="7" width="18" height="10" rx="1" />
+    </symbol>
   </defs>
 </svg>
 
 <header class="page-header">
-  <div class="t-caption">NeSyCat · Wireframe · v0.4 · 1728×1080 (16″ MBP scaled)</div>
+  <div class="t-caption">NeSyCat · Wireframe · v0.5 · 1728×1080 (16″ MBP scaled)</div>
   <h1 class="t-h1">Editor chrome — pixel-faithful to today.</h1>
   <p>
     Each scene is a 1728×1080 frame sized for a 16″ MacBook Pro at default
@@ -116,7 +136,7 @@
     management (search, diagram list, +new) is no longer in the sidebar;
     it lives in a separate picker. Top toolbar floats over the canvas with
     two glass buttons. JSON panel collapsed. Zoom cluster bottom-left,
-    sliding with the sidebar.
+    inset from the fixed-width rail (<code>--sidebar-offset</code>).
   </p>
 
   <div class="editor-frame">
@@ -141,7 +161,6 @@
         </div>
       </div>
     </aside>
-    <button class="sidebar-handle" type="button" aria-label="Collapse sidebar" title="Collapse sidebar">‹</button>
 
     <div class="canvas-area">
       <!-- Top-left toolbar -->
@@ -181,13 +200,11 @@
     <div class="note"><span class="pin">I</span><code>weight</code> slot (6): scalar <code>Mass</code>.</div>
     <div class="note"><span class="pin">J</span>Slot −2 <code>id</code> intentionally absent — <code>types.ts:29</code>: "Auto-generated, unique, internal — never user-facing."</div>
     <div class="note"><span class="pin">K</span>Buttons 40×40, 6 px radius. Active state tinted with <code>rgba(accent, 0.18)</code> + accent border. Hover swaps to glass-button bg + glass border.</div>
-    <div class="note"><span class="pin">L</span><code>‹</code> collapse handle attached to right edge, slides rail to 0 width via <code>--sidebar-offset</code>.</div>
-
     <h3>Canvas chrome (<code>Canvas.tsx</code>)</h3>
-    <div class="note"><span class="pin">M</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left, slides on collapse with 200 ms transition.</div>
+    <div class="note"><span class="pin">L</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left (rail fixed at 56 px — not collapsible in this wireframe).</div>
     <div class="note"><span class="pin">N</span>Each button: <code>panelStyle()</code> + 8 px radius + 6×14 padding, 12 px / 600 wt secondary text.</div>
     <div class="note"><span class="pin">O</span>"Straight" label toggles to "Smooth" when clicked; tooltip carries the current state.</div>
-    <div class="note"><span class="pin">P</span>JSON button — open state in Scene 4 (panel expands below it, button stays visible above).</div>
+    <div class="note"><span class="pin">P</span>JSON button — open state in Scene 14 (panel expands below it, button stays visible above).</div>
     <div class="note"><span class="pin">Q</span>Zoom cluster from React Flow's <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, also tracks sidebar offset.</div>
 
     <h3>Redesign hooks</h3>
@@ -198,20 +215,20 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 2: Sidebar collapsed ═══════ -->
+<!-- ═══════ Scene 5: name popover (slot -1) ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 2 — sidebar collapsed</h2>
+  <h2 class="t-h1">Scene 5 — name popover</h2>
   <p class="lead">
-    Click the handle and the sidebar slides to 0 width (200 ms transition,
-    matches <code>EditorSidebar.tsx</code> setting <code>--sidebar-offset</code>
-    to <code>0px</code>). The handle stays anchored — its <code>left</code>
-    now resolves to 0 — so the user always has an obvious affordance to
-    re-open. The top-left toolbar and the bottom-left zoom cluster slide
-    along with it; the JSON button in the top-right is unaffected.
+    Clicking the <code>name</code> button opens a popover anchored to the
+    right of the rail at the button's y. Header strip names the slot, body
+    holds the editor, and a thin "visibility" footer parks the 3-state
+    "Off · Selected · All" toggle. Rename today happens inline (double-click
+    on the canvas, <code>DiagramNode.tsx:360-448</code>); the input here is
+    a faster alternative when the shape is already selected.
   </p>
 
-  <div class="editor-frame is-sidebar-closed">
+  <div class="editor-frame">
     <div class="canvas-bg"></div>
 
     <aside class="sidebar">
@@ -220,53 +237,724 @@
           <svg class="logo-mark"><use href="#logo-mark"/></svg>
         </a>
         <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+          <button class="sidebar-tool tool-name is-active" type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"         type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"           type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"          type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"          type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"      type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"      type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"         type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
     </aside>
-    <button class="sidebar-handle" type="button" aria-label="Open sidebar">›</button>
 
     <div class="canvas-area">
       <div class="toolbar-topleft">
-        <div class="kinds-anchor">
-          <button class="panel-btn" type="button">Kinds</button>
-        </div>
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
         <button class="panel-btn" type="button">Straight</button>
       </div>
-
-      <div class="topright">
-        <button class="panel-btn" type="button">JSON</button>
-      </div>
-
-      <div class="controls-cluster" aria-label="Zoom controls">
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
         <button type="button"><svg><use href="#ic-plus"/></svg></button>
         <button type="button"><svg><use href="#ic-minus"/></svg></button>
         <button type="button"><svg><use href="#ic-fit"/></svg></button>
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
+
+      <!-- Popover anchored to the name button (i=0, top 60). -->
+      <div class="tool-popover" style="top: 60px; width: 280px">
+        <div class="head">name · slot −1</div>
+        <div class="body">
+          <span class="body-label">Rename selected</span>
+          <input class="text-input" type="text" value="Y" />
+          <span class="hint">Or double-click a name on the canvas to edit inline.</span>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg" type="button">Selected</button>
+            <button class="seg is-on" type="button">All</button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
   <div class="annotations">
-    <h3>Handle</h3>
-    <div class="note"><span class="pin">T</span>Single button, 28×64, glass panel with no left border so it visually attaches to the sidebar or canvas edge.</div>
-    <div class="note"><span class="pin">U</span>Arrow flips from <code>‹</code> (open → close) to <code>›</code> (closed → open) to match the action it triggers.</div>
-    <div class="note"><span class="pin">V</span><code>left: var(--sidebar-offset)</code> with a 200 ms transition — the handle slides in lockstep with the sidebar.</div>
-    <div class="note"><span class="pin">W</span>The whole sidebar (brand row, search, list) is still mounted under the hood — width 0 + <code>overflow: hidden</code> hides it without unmounting state.</div>
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.name?: string</code> at <code>types.ts:118</code> — only set on labeled leaves.</div>
+    <div class="note"><span class="pin">B</span>Today's UI: inline rename via <code>DiagramNode.tsx:360-448</code>. No popover yet.</div>
+    <div class="note"><span class="pin">C</span><code>Off</code> globally hides name labels; <code>Selected</code> shows the label only on the active selection; <code>All</code> = today's behaviour.</div>
   </div>
 </section>
 
-<!-- ═══════ Scene 3: Kinds menu open ═══════ -->
+<!-- ═══════ Scene 6: points popover (slot 0) ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 3 — Kinds menu open</h2>
+  <h2 class="t-h1">Scene 6 — points popover</h2>
+  <p class="lead">
+    The <code>points</code> popover is visibility-first — there's no
+    editor for the nested-shape tree itself; points are added via the
+    <code>+</code> buttons that surface on a selected shape
+    (<code>DiagramNode.tsx:514-537</code>). Today's
+    <code>visibility.points</code> flag maps to "All" / "Off"; the
+    new "Selected" middle step shows handles only on the active shape.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"             type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points is-active" type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"             type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"            type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"            type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"        type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"        type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"           type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the points button (i=1, top 106). -->
+      <div class="tool-popover" style="top: 106px; width: 280px">
+        <div class="head">points · slot 0</div>
+        <div class="body">
+          <span class="hint">
+            Add points via the <strong>+</strong> buttons that surface on
+            a selected shape. The set of slots offered is schema-driven
+            (<code>enumerateAddable()</code> reads <code>ShapePoints[K]</code>
+            from <code>types.ts:38-65</code>).
+          </span>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg is-on" type="button">Selected</button>
+            <button class="seg" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.points: ShapePoints[K]</code> at <code>types.ts:119</code> — recursive sub-shape tree, slot cardinalities per <code>ShapeKind</code>.</div>
+    <div class="note"><span class="pin">B</span>Today: <code>visibility.points</code> in <code>store.ts:8</code>; CSS gate <code>.points-hidden .point-label</code> in <code>app/globals.css</code>.</div>
+    <div class="note"><span class="pin">C</span>"Selected" is the new middle step — shows handles only on the active shape.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 7: kind popover (slot 1) ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 7 — kind popover</h2>
+  <p class="lead">
+    The <code>kind</code> popover picks one of the five <code>ShapeKind</code>s
+    from <code>types.ts:38-65</code>: <code>empty</code>, <code>triangle</code>,
+    <code>rhombus</code>, <code>circle</code>, <code>rectangle</code>. Today
+    the kind is fixed at creation — this introduces a new mutation
+    ("change kind of selected") that <code>mutations.ts</code> doesn't have
+    yet. Tile glyphs match the <code>geometryRegistry</code> registry order.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"           type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"         type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind is-active" type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"          type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"          type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"      type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"      type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"         type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the kind button (i=2, top 152). -->
+      <div class="tool-popover" style="top: 152px; width: 296px">
+        <div class="head">kind · slot 1</div>
+        <div class="body">
+          <span class="body-label">Change kind of selected</span>
+          <div class="kind-picker">
+            <button class="tile" type="button" title="empty">
+              <svg><use href="#kind-empty"/></svg>
+              <span class="tile-label">empty</span>
+            </button>
+            <button class="tile is-on" type="button" title="triangle">
+              <svg><use href="#kind-triangle"/></svg>
+              <span class="tile-label">triangle</span>
+            </button>
+            <button class="tile" type="button" title="rhombus">
+              <svg><use href="#kind-rhombus"/></svg>
+              <span class="tile-label">rhombus</span>
+            </button>
+            <button class="tile" type="button" title="circle">
+              <svg><use href="#kind-circle"/></svg>
+              <span class="tile-label">circle</span>
+            </button>
+            <button class="tile" type="button" title="rectangle">
+              <svg><use href="#kind-rectangle"/></svg>
+              <span class="tile-label">rect</span>
+            </button>
+          </div>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg" type="button">Selected</button>
+            <button class="seg is-on" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.kind: K</code> at <code>types.ts:120</code>; <code>ShapeKind = keyof ShapePoints</code> at <code>types.ts:70</code>.</div>
+    <div class="note"><span class="pin">B</span>Today: no kind-change mutation in <code>mutations.ts</code>; only set at <code>addNode()</code> creation time.</div>
+    <div class="note"><span class="pin">C</span>Tile glyphs match the registry order rendered in the legacy "Kinds" dropdown (Scene 13).</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 8: order popover (slot 2) ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 8 — order popover</h2>
+  <p class="lead">
+    The <code>order</code> popover is a discrete numeric editor — vertical
+    slider with integer notches, plus a numeric box for typing the value
+    directly (mirroring Adobe Fresco's "Tamaño" slider). Today
+    <code>Order</code> is set programmatically at <code>addNode()</code>;
+    there's no UI to change it post-hoc.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"            type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"          type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"            type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order is-active" type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"           type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"       type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"       type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"          type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the order button (i=3, top 198). -->
+      <div class="tool-popover" style="top: 198px; width: 280px">
+        <div class="head">order · slot 2</div>
+        <div class="body">
+          <div style="display:flex; align-items:center; gap:12px; justify-content:space-between;">
+            <span class="body-label">Order</span>
+            <input class="num-input" type="text" value="2" aria-label="Order value" />
+          </div>
+          <div class="slider-col">
+            <div class="slider-stack">
+              <div class="slider-track">
+                <div class="slider-thumb" style="top: 70%"></div>
+              </div>
+            </div>
+            <div class="slider-notches" aria-hidden="true">
+              <span>5</span><span>4</span><span>3</span><span>2</span><span>1</span><span>0</span>
+            </div>
+            <div class="preview-col">
+              <div class="preview-disk" style="width: 64px; height: 64px"></div>
+              <span class="hint" style="text-align:center;">order = 2<br/>(discrete steps)</span>
+            </div>
+          </div>
+          <span class="hint">Drag the slider or type a number; the preview scales with the order.</span>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg is-on" type="button">Selected</button>
+            <button class="seg" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.order: Order</code> at <code>types.ts:121</code>; <code>Order = number</code> at <code>types.ts:74</code>.</div>
+    <div class="note"><span class="pin">B</span>Today: assigned at creation via <code>mutations.ts:118</code> (<code>order = d.nodes.length + 1</code>). No UI to change it.</div>
+    <div class="note"><span class="pin">C</span>Slider snaps to integers; for the wireframe, range is shown as 0–5 with the thumb sitting at value 2.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 9: color popover (slot 3) ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 9 — color popover</h2>
+  <p class="lead">
+    The <code>color</code> popover is a full HSV picker — annular hue ring
+    + inner S/V square, HSB sliders, alpha track, swatches grid. Mirrors
+    the layout of Adobe Fresco's "Color" panel. Today there's no picker;
+    shapes initialise to <code>DEFAULT_COLOR = [59/255, 130/255, 246/255]</code>
+    from <code>color.ts:5</code> and never change.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"            type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"          type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"            type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"           type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color is-active" type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"       type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"       type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"          type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the color button (i=4, top 244). -->
+      <div class="tool-popover" style="top: 244px; width: 280px">
+        <div class="head">color · slot 3</div>
+        <div class="body">
+          <div class="color-wheel" aria-label="HSV wheel">
+            <div class="color-current" title="Current color"></div>
+            <svg viewBox="0 0 220 220" width="220" height="220">
+              <defs>
+                <linearGradient id="cw-sv-h" x1="0" y1="0" x2="1" y2="0">
+                  <stop offset="0" stop-color="#fff"/>
+                  <stop offset="1" stop-color="rgb(59,130,246)"/>
+                </linearGradient>
+                <linearGradient id="cw-sv-v" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0" stop-color="rgba(0,0,0,0)"/>
+                  <stop offset="1" stop-color="#000"/>
+                </linearGradient>
+              </defs>
+              <!-- hue ring (rough; 8-stop conic via dashed segments) -->
+              <g fill="none" stroke-width="22">
+                <circle cx="110" cy="110" r="92" stroke="#f00" stroke-dasharray="72 506"  stroke-dashoffset="0"/>
+                <circle cx="110" cy="110" r="92" stroke="#ff0" stroke-dasharray="72 506"  stroke-dashoffset="-72"/>
+                <circle cx="110" cy="110" r="92" stroke="#0f0" stroke-dasharray="72 506"  stroke-dashoffset="-144"/>
+                <circle cx="110" cy="110" r="92" stroke="#0ff" stroke-dasharray="72 506"  stroke-dashoffset="-216"/>
+                <circle cx="110" cy="110" r="92" stroke="#00f" stroke-dasharray="72 506"  stroke-dashoffset="-288"/>
+                <circle cx="110" cy="110" r="92" stroke="#f0f" stroke-dasharray="72 506"  stroke-dashoffset="-360"/>
+                <circle cx="110" cy="110" r="92" stroke="#f00" stroke-dasharray="72 506"  stroke-dashoffset="-432"/>
+              </g>
+              <!-- S/V square inside the ring -->
+              <rect x="60" y="60" width="100" height="100" fill="url(#cw-sv-h)"/>
+              <rect x="60" y="60" width="100" height="100" fill="url(#cw-sv-v)"/>
+              <!-- markers -->
+              <circle cx="195" cy="110" r="6" fill="none" stroke="#fff" stroke-width="2"/>
+              <circle cx="120" cy="100" r="5" fill="none" stroke="#fff" stroke-width="2"/>
+            </svg>
+          </div>
+          <div class="color-sliders">
+            <div class="slider-row">
+              <span class="row-label">H</span>
+              <div class="h-track hue"><div class="h-thumb" style="left: 60%"></div></div>
+              <input class="num-input" value="216" />
+            </div>
+            <div class="slider-row">
+              <span class="row-label">S</span>
+              <div class="h-track sat"><div class="h-thumb" style="left: 76%"></div></div>
+              <input class="num-input" value="76" />
+            </div>
+            <div class="slider-row">
+              <span class="row-label">B</span>
+              <div class="h-track val"><div class="h-thumb" style="left: 96%"></div></div>
+              <input class="num-input" value="96" />
+            </div>
+            <div class="slider-row">
+              <span class="row-label">α</span>
+              <div class="h-track alpha"><div class="h-thumb" style="left: 100%"></div></div>
+              <input class="num-input" value="100" />
+            </div>
+          </div>
+          <span class="body-label">Swatches</span>
+          <div class="swatches">
+            <div class="sw" style="background:rgb(59,130,246)"></div>
+            <div class="sw" style="background:rgb(99, 157, 255)"></div>
+            <div class="sw" style="background:rgb(155, 89, 235)"></div>
+            <div class="sw" style="background:rgb(236, 72, 153)"></div>
+            <div class="sw" style="background:rgb(244, 114, 91)"></div>
+            <div class="sw" style="background:rgb(245, 158, 11)"></div>
+            <div class="sw" style="background:rgb(234, 211, 16)"></div>
+            <div class="sw" style="background:rgb(132, 204, 22)"></div>
+            <div class="sw" style="background:rgb(34, 197, 94)"></div>
+            <div class="sw" style="background:rgb(20, 184, 166)"></div>
+            <div class="sw" style="background:rgb(14, 165, 233)"></div>
+            <div class="sw" style="background:rgb(99, 102, 241)"></div>
+            <div class="sw" style="background:rgba(255, 255, 255, 0.9)"></div>
+            <div class="sw" style="background:rgba(255, 255, 255, 0.5)"></div>
+            <div class="sw" style="background:rgba(255, 255, 255, 0.25)"></div>
+            <div class="sw" style="background:rgba(0, 0, 0, 0.5)"></div>
+            <div class="sw" style="background:rgba(0, 0, 0, 0.8)"></div>
+            <div class="sw" style="background:#000"></div>
+          </div>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg" type="button">Selected</button>
+            <button class="seg is-on" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.color: Color</code> at <code>types.ts:122</code>; <code>Color = [r, g, b] ∈ [0, 1]³</code> at <code>types.ts:79</code>.</div>
+    <div class="note"><span class="pin">B</span>Today: no picker. Shapes init to <code>DEFAULT_COLOR</code> from <code>color.ts:5</code> (same as <code>--color-accent-rgb</code>).</div>
+    <div class="note"><span class="pin">C</span><code>Off</code> renders shapes monochrome (outlines only); <code>Selected</code> tints the selection alone; <code>All</code> matches today.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 10: transform popover (slot 4) ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 10 — transform popover</h2>
+  <p class="lead">
+    The <code>transform</code> popover exposes the full <code>SpaceTime</code>
+    affine — translation (<code>tx</code>, <code>ty</code>), rotation
+    (<code>θ</code>), and scale (<code>sx</code>, <code>sy</code>). Today
+    only translation is bound to a UI (React Flow drag, committed via
+    <code>updateNodeTranslations()</code> in <code>mutations.ts</code>);
+    rotation/scale fields exist on <code>Space</code> but aren't editable.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"                type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"              type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"                type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"               type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"               type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform is-active" type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"           type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"              type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the transform button (i=5, top 290). -->
+      <div class="tool-popover" style="top: 290px; width: 296px">
+        <div class="head">transform · slot 4</div>
+        <div class="body">
+          <span class="body-label">Translate</span>
+          <div class="txn-grid">
+            <div class="cell"><span class="row-label">tx</span><input class="num-input" value="120" /></div>
+            <div class="cell"><span class="row-label">ty</span><input class="num-input" value="-40" /></div>
+          </div>
+          <span class="body-label">Rotate / scale</span>
+          <div class="txn-grid">
+            <div class="cell"><span class="row-label">θ</span><input class="num-input" value="0°" /></div>
+            <div class="cell"><span class="row-label">sx</span><input class="num-input" value="1.00" /></div>
+            <div class="cell" style="grid-column: 1"><span class="row-label">sy</span><input class="num-input" value="1.00" /></div>
+            <button class="reset-btn" type="button">Reset</button>
+          </div>
+          <span class="hint">Drag on canvas to translate. Rotation / scale aren't bound to handles yet.</span>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg is-on" type="button">Selected</button>
+            <button class="seg" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.transform: SpaceTime</code> at <code>types.ts:123</code>; <code>Space</code> + <code>Time</code> at <code>types.ts:86-92</code>.</div>
+    <div class="note"><span class="pin">B</span>Today: only translation editable. Rotation / scale fields exist but no UI.</div>
+    <div class="note"><span class="pin">C</span>Visibility "Selected" shows transform handles only on the active selection — useful when many shapes overlap.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 11: equations popover (slot 5) ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 11 — equations popover</h2>
+  <p class="lead">
+    The <code>equations</code> popover lists the shape's
+    <code>Expression[]</code> (rational over shape refs, see
+    <code>types.ts:99-100</code>). Each equation reads as
+    <code>thisShape = E</code>. Today the field exists but no UI edits it —
+    this popover is a stub for the future expressions grammar.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"                type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"              type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"                type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"               type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"               type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"           type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations is-active" type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight"              type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the equations button (i=6, top 336). -->
+      <div class="tool-popover" style="top: 336px; width: 296px">
+        <div class="head">equations · slot 5</div>
+        <div class="body">
+          <span class="body-label">this = …</span>
+          <div class="eq-list">
+            <div class="eq-row"><span>x + y</span><span class="delete">×</span></div>
+            <div class="eq-row"><span>2 · z − w</span><span class="delete">×</span></div>
+          </div>
+          <button class="eq-add" type="button">+ Add equation</button>
+          <span class="hint">Encoding: strings are shape refs, numbers literals, objects ops (<code>+ − * /</code>). Grammar at <code>types.ts:99-100</code>.</span>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg" type="button">Off</button>
+            <button class="seg is-on" type="button">Selected</button>
+            <button class="seg" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.equations: Expression[]</code> at <code>types.ts:124</code>; <code>Expression</code> at <code>types.ts:100</code>.</div>
+    <div class="note"><span class="pin">B</span>Each row reads as an implicit <code>thisShape = E</code> equation.</div>
+    <div class="note"><span class="pin">C</span>Today: no UI; the field is always <code>[]</code> at creation. This popover is a stub.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 12: weight popover (slot 6) ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 12 — weight popover</h2>
+  <p class="lead">
+    The <code>weight</code> popover is the continuous twin of Scene 8 —
+    same Fresco-style slider, but with 1-decimal floats and no integer
+    snap. <code>Mass</code> is a scalar alias for <code>number</code>
+    (<code>types.ts:104</code>); today every shape initialises to
+    <code>1</code> at <code>mutations.ts:64</code> and never changes.
+  </p>
+
+  <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
+    <aside class="sidebar">
+      <div class="sidebar-inner">
+        <a class="sidebar-brand" href="#" aria-label="NeSyCat Semiotics">
+          <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        </a>
+        <div class="sidebar-tools" role="toolbar" aria-label="Shape editor">
+          <button class="sidebar-tool tool-name"             type="button" title="name (slot -1)"><svg><use href="#ic-name"/></svg></button>
+          <button class="sidebar-tool tool-points"           type="button" title="points (slot 0)"><svg><use href="#ic-points"/></svg></button>
+          <button class="sidebar-tool tool-kind"             type="button" title="kind (slot 1)"><svg><use href="#ic-kind"/></svg></button>
+          <button class="sidebar-tool tool-order"            type="button" title="order (slot 2)"><svg><use href="#ic-order"/></svg></button>
+          <button class="sidebar-tool tool-color"            type="button" title="color (slot 3)"><svg><use href="#ic-color"/></svg></button>
+          <button class="sidebar-tool tool-transform"        type="button" title="transform (slot 4)"><svg><use href="#ic-transform"/></svg></button>
+          <button class="sidebar-tool tool-equations"        type="button" title="equations (slot 5)"><svg><use href="#ic-equations"/></svg></button>
+          <button class="sidebar-tool tool-weight is-active" type="button" title="weight (slot 6)"><svg><use href="#ic-weight"/></svg></button>
+        </div>
+      </div>
+    </aside>
+
+    <div class="canvas-area">
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor"><button class="panel-btn" type="button">Kinds</button></div>
+        <button class="panel-btn" type="button">Straight</button>
+      </div>
+      <div class="topright"><button class="panel-btn" type="button">JSON</button></div>
+      <div class="controls-cluster">
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
+      </div>
+
+      <!-- Popover anchored to the weight button (i=7, top 382). -->
+      <div class="tool-popover" style="top: 382px; width: 280px">
+        <div class="head">weight · slot 6</div>
+        <div class="body">
+          <div style="display:flex; align-items:center; gap:12px; justify-content:space-between;">
+            <span class="body-label">Mass</span>
+            <input class="num-input" type="text" value="1.0" aria-label="Weight value" />
+          </div>
+          <div class="slider-col">
+            <div class="slider-stack">
+              <div class="slider-track">
+                <div class="slider-thumb" style="top: 80%"></div>
+              </div>
+            </div>
+            <div class="slider-notches" aria-hidden="true">
+              <span>5</span><span>4</span><span>3</span><span>2</span><span>1</span><span>0</span>
+            </div>
+            <div class="preview-col">
+              <div class="preview-disk" style="width: 48px; height: 48px"></div>
+              <span class="hint" style="text-align:center;">weight = 1.0<br/>(continuous)</span>
+            </div>
+          </div>
+          <span class="hint">Drag the slider or type a 1-decimal value; preview scales with mass.</span>
+        </div>
+        <div class="vis-footer">
+          <span class="footer-label">Visibility</span>
+          <div class="vis-seg" role="radiogroup">
+            <button class="seg is-on" type="button">Off</button>
+            <button class="seg" type="button">Selected</button>
+            <button class="seg" type="button">All</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Source of truth</h3>
+    <div class="note"><span class="pin">A</span><code>Shape.weight: Mass</code> at <code>types.ts:125</code>; <code>Mass = number</code> at <code>types.ts:104</code>.</div>
+    <div class="note"><span class="pin">B</span>Today: no UI. Initialised to <code>1</code> at <code>mutations.ts:64</code>.</div>
+    <div class="note"><span class="pin">C</span>This popover defaults visibility to <code>Off</code> — weight isn't typically surfaced on the canvas.</div>
+  </div>
+</section>
+
+<!-- ═══════ Scene 13: Kinds menu open ═══════ -->
+
+<section class="wireframe-section">
+  <h2 class="t-h1">Scene 13 — Kinds menu open</h2>
   <p class="lead">
     Hovering the "Kinds" button reveals a glass dropdown 6 px below it.
     Eight rows: five per-kind toggles (in registry order — Empties,
@@ -296,7 +984,6 @@
         </div>
       </div>
     </aside>
-    <button class="sidebar-handle" type="button" aria-label="Collapse sidebar">‹</button>
 
     <div class="canvas-area">
       <div class="toolbar-topleft">
@@ -374,10 +1061,10 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 4: JSON panel open ═══════ -->
+<!-- ═══════ Scene 14: JSON panel open ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 4 — JSON panel open</h2>
+  <h2 class="t-h1">Scene 14 — JSON panel open</h2>
   <p class="lead">
     JSON button toggles a 400-wide, 500-max-height glass panel. Header strip
     carries a "DIAGRAM DATA" caption (11 px Mono / 600 wt / uppercase /
@@ -405,7 +1092,6 @@
         </div>
       </div>
     </aside>
-    <button class="sidebar-handle" type="button" aria-label="Collapse sidebar">‹</button>
 
     <div class="canvas-area">
       <div class="toolbar-topleft">
@@ -485,10 +1171,10 @@
   </div>
 </section>
 
-<!-- ═══════ Scene 5: Star-prompt modal ═══════ -->
+<!-- ═══════ Scene 15: Star-prompt modal ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 5 — Star-prompt modal</h2>
+  <h2 class="t-h1">Scene 15 — Star-prompt modal</h2>
   <p class="lead">
     After ~45 s idle, a full-screen modal asks the user to star the GitHub
     repo. 50% dark scrim over the editor, body centred at ~420 px wide.

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>02 — Wireframe · Editor chrome</title>
+  <title>02 — Wireframe · Editor chrome (16″ MBP)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="stylesheet"
@@ -12,131 +12,165 @@
 </head>
 <body>
 
+<!-- Reusable SVG logo (LogoMark from EditorSidebar.tsx). -->
+<svg width="0" height="0" style="position: absolute" aria-hidden="true">
+  <defs>
+    <symbol id="logo-mark" viewBox="0 0 24 24">
+      <rect x="2" y="2" width="20" height="20"
+            fill="rgba(59,130,246,0.1)" stroke="rgb(59,130,246)" stroke-width="1.3" />
+      <polygon points="12,3 21,12 12,21 3,12"
+               fill="rgba(59,130,246,0.25)" stroke="rgb(59,130,246)" stroke-width="1.3" />
+      <circle cx="12" cy="12" r="2.2" fill="rgb(59,130,246)" />
+    </symbol>
+    <!-- Zoom-control icons (match React Flow's <Controls />). -->
+    <symbol id="ic-plus" viewBox="0 0 24 24">
+      <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" fill="none" />
+    </symbol>
+    <symbol id="ic-minus" viewBox="0 0 24 24">
+      <path d="M5 12h14" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" fill="none" />
+    </symbol>
+    <symbol id="ic-fit" viewBox="0 0 24 24">
+      <path d="M4 9V4h5M20 9V4h-5M4 15v5h5M20 15v5h-5"
+            stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    </symbol>
+    <symbol id="ic-lock" viewBox="0 0 24 24">
+      <rect x="5" y="11" width="14" height="9" rx="1.5"
+            stroke="currentColor" stroke-width="2" fill="none" />
+      <path d="M8 11V7a4 4 0 1 1 8 0v4"
+            stroke="currentColor" stroke-width="2" fill="none" />
+    </symbol>
+  </defs>
+</svg>
+
 <header class="page-header">
-  <div class="t-caption">NeSyCat · Wireframe · v0</div>
-  <h1 class="t-h1">Editor chrome — current layout.</h1>
+  <div class="t-caption">NeSyCat · Wireframe · v0.2 · 1728×1080 (16″ MBP scaled)</div>
+  <h1 class="t-h1">Editor chrome — pixel-faithful to today.</h1>
   <p>
-    Low-fidelity wireframe of the editor's UI shell as it ships today. The
-    React Flow canvas in the middle (shapes, points, wires, the JSON spine) is
-    rendered as a labelled placeholder — it's intentionally out of scope.
-    Everything around it is fair game to move, reshape, or replace. Edit the
-    boxes in <code>index.html</code> and <code>styles.css</code> directly to
-    iterate.
+    Each scene is a 1728×1080 frame sized for a 16″ MacBook Pro at default
+    scaling. Sidebar widths, panel sizes, button padding, font weights, kind
+    labels, hotkey chips, JSON-panel header copy, and React Flow controls
+    are pulled directly from <code>components/editor/EditorSidebar.tsx</code>
+    and <code>components/editor/Canvas.tsx</code>. The React Flow canvas
+    itself (shapes, points, wires, JSON spine) is intentionally left as a
+    dot-grid background — it's out of scope for the redesign.
   </p>
 </header>
 
 <!-- ═══════ Scene 1: default editor state ═══════ -->
 
 <section class="wireframe-section">
-  <h2 class="t-h1">Scene 1 — default editor state</h2>
+  <h2 class="t-h1">Scene 1 — default state</h2>
   <p class="lead">
-    Signed-in user has just opened a diagram. Left sidebar expanded, top-left
-    toolbar visible, JSON panel closed in the top-right corner, zoom controls
-    bottom-left.
+    Signed-in user has just opened a diagram. Left sidebar 240 px open. Top
+    toolbar floats over the canvas with two glass buttons. JSON panel
+    collapsed. Zoom cluster bottom-left, sliding with the sidebar.
   </p>
 
-  <div class="with-annotations">
-    <div class="editor-frame">
+  <div class="editor-frame">
+    <!-- Dot-grid canvas background -->
+    <div class="canvas-bg"></div>
 
-      <!-- Left sidebar -->
-      <aside class="sidebar">
-        <div class="sidebar-brand">
-          <span class="logo-mark"></span>
-          <span class="name">NeSyCat</span>
-        </div>
+    <!-- Left sidebar -->
+    <aside class="sidebar">
+      <a class="sidebar-brand" href="#" title="Back to landing">
+        <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        <span class="brand-name">NeSyCat Semiotics</span>
+      </a>
+      <div class="sidebar-search-row">
         <div class="sidebar-search">
-          <input type="text" placeholder="Search…" />
-          <div class="plus">+</div>
+          <input type="search" placeholder="Search…" aria-label="Search diagrams" />
         </div>
-        <div class="sidebar-list">
-          <div class="diagram-row active">
-            <span class="title">Untitled diagram</span>
-            <span class="meta">just now · L1, L2, L3</span>
-          </div>
-          <div class="diagram-row">
-            <span class="title">Categorical layer α</span>
-            <span class="meta">3h ago · 12 pts</span>
-          </div>
-          <div class="diagram-row">
-            <span class="title">Logical 2Mon-BLat</span>
-            <span class="meta">yesterday · 8 pts</span>
-          </div>
-          <div class="diagram-row">
-            <span class="title">Grammar substitution</span>
-            <span class="meta">2 days ago · 4 pts</span>
-          </div>
-          <div class="diagram-row">
-            <span class="title">Binary classification</span>
-            <span class="meta">May 6 · 21 pts</span>
-          </div>
-          <div class="diagram-row">
-            <span class="title">MeasU / GeomU universes</span>
-            <span class="meta">May 5 · 6 pts</span>
-          </div>
+        <button class="sidebar-new" type="button" aria-label="New diagram" title="New diagram">+</button>
+      </div>
+      <div class="sidebar-list">
+        <div class="diagram-row active">
+          <span class="title">Mortimer&apos;s Thesis</span>
+          <span class="meta">2d ago</span>
         </div>
-        <div class="sidebar-collapse">‹</div>
-      </aside>
-
-      <!-- Canvas + floating chrome -->
-      <div class="canvas-area">
-
-        <!-- Top-left toolbar -->
-        <div class="glass-bar toolbar-topleft">
-          <button class="glass-btn">Kinds ▾</button>
-          <div class="divider"></div>
-          <div class="toolbar-toggle">
-            <button class="glass-btn is-active">Straight</button>
-            <button class="glass-btn">Smooth</button>
-          </div>
+        <div class="diagram-row">
+          <span class="title">CT for Programmers</span>
+          <span class="meta">2d ago</span>
         </div>
-
-        <!-- Top-right JSON panel (closed) -->
-        <div class="glass-bar json-panel-closed">
-          <button class="glass-btn">JSON</button>
+        <div class="diagram-row">
+          <span class="title">Archetypon Logicon</span>
+          <span class="meta">3d ago</span>
         </div>
-
-        <!-- Canvas placeholder -->
-        <div class="canvas-placeholder">
-          <div>
-            <strong>React Flow canvas — out of scope.</strong><br />
-            Shapes (rectangle, triangle, circle, rhombus, empty), points,
-            wires, the JSON spine. Rendered unchanged from today; the redesign
-            doesn't touch what's drawn here.
-          </div>
+        <div class="diagram-row">
+          <span class="title">PAZ CSG</span>
+          <span class="meta">3d ago</span>
         </div>
-
-        <!-- Bottom-left zoom controls -->
-        <div class="controls-cluster">
-          <button>+</button>
-          <button>−</button>
-          <button>⊡</button>
-          <button>⤢</button>
+        <div class="diagram-row">
+          <span class="title">PAZ Renderer types.py</span>
+          <span class="meta">3d ago</span>
         </div>
+        <div class="diagram-row">
+          <span class="title">Alice kills a cat</span>
+          <span class="meta">4d ago</span>
+        </div>
+        <div class="diagram-row">
+          <span class="title">Human Sysmer</span>
+          <span class="meta">6d ago</span>
+        </div>
+        <div class="diagram-row">
+          <span class="title">Semiotic Types</span>
+          <span class="meta">11d ago</span>
+        </div>
+        <div class="diagram-row">
+          <span class="title">Datenbank Vorl. + FK</span>
+          <span class="meta">15d ago</span>
+        </div>
+      </div>
+      <div class="sidebar-collapse">‹</div>
+    </aside>
 
+    <div class="canvas-area">
+      <!-- Top-left toolbar -->
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor">
+          <button class="panel-btn" type="button">Kinds</button>
+        </div>
+        <button class="panel-btn" type="button"
+                title="Edge path: straight — click to switch">Straight</button>
+      </div>
+
+      <!-- Top-right JSON button (collapsed) -->
+      <div class="topright">
+        <button class="panel-btn" type="button">JSON</button>
+      </div>
+
+      <!-- Bottom-left React Flow controls -->
+      <div class="controls-cluster" aria-label="Zoom controls">
+        <button type="button" title="Zoom in"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button" title="Zoom out"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button" title="Fit view"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button" title="Lock"><svg><use href="#ic-lock"/></svg></button>
       </div>
     </div>
+  </div>
 
-    <aside class="annotations">
-      <h3>Sidebar</h3>
-      <div class="note"><span class="pin">A</span>Logo + project name. Click → editor home.</div>
-      <div class="note"><span class="pin">B</span>Search filters the diagram list in place.</div>
-      <div class="note"><span class="pin">C</span><strong>+</strong> creates a new untitled diagram and navigates to it.</div>
-      <div class="note"><span class="pin">D</span>Diagram rows: title + relative-time meta. Hover reveals edit/delete.</div>
-      <div class="note"><span class="pin">E</span><code>‹</code> arrow collapses the sidebar to 0 width; toggle re-expands.</div>
+  <div class="annotations">
+    <h3>Sidebar (<code>EditorSidebar.tsx</code>)</h3>
+    <div class="note"><span class="pin">A</span>Brand row 14×16 padding, 15 px / 600 wt, border-bottom glass-border.</div>
+    <div class="note"><span class="pin">B</span>Search input 36 px high, 13 px text, glass-border, with clear-button when filled.</div>
+    <div class="note"><span class="pin">C</span><strong>+</strong> button 36×36, glass-border, swaps to spinner while creating.</div>
+    <div class="note"><span class="pin">D</span>Rows 10×16 padding. Active row tinted with <code>rgba(accent, 0.10)</code>. Hover reveals pen + ✕.</div>
+    <div class="note"><span class="pin">E</span><code>‹</code> collapse arrow attached to right edge, slides sidebar to 0 width via <code>--sidebar-offset</code>.</div>
 
-      <h3>Canvas chrome</h3>
-      <div class="note"><span class="pin">F</span>Top-left toolbar slides right with the sidebar (CSS var <code>--sidebar-offset</code>).</div>
-      <div class="note"><span class="pin">G</span>"Kinds ▾" on hover/click opens the menu in Scene 2.</div>
-      <div class="note"><span class="pin">H</span>Straight / Smooth toggle controls edge path style.</div>
-      <div class="note"><span class="pin">I</span>JSON button toggles the open-state panel in Scene 3.</div>
-      <div class="note"><span class="pin">J</span>Zoom controls: + / − / fit-view / lock. From React Flow's built-in <code>&lt;Controls /&gt;</code>.</div>
+    <h3>Canvas chrome (<code>Canvas.tsx</code>)</h3>
+    <div class="note"><span class="pin">F</span>Top-left toolbar at 12 px from top, <code>12px + --sidebar-offset</code> from left, slides on collapse with 200 ms transition.</div>
+    <div class="note"><span class="pin">G</span>Each button: <code>panelStyle()</code> + 8 px radius + 6×14 padding, 12 px / 600 wt secondary text.</div>
+    <div class="note"><span class="pin">H</span>"Straight" label toggles to "Smooth" when clicked; tooltip carries the current state.</div>
+    <div class="note"><span class="pin">I</span>JSON button — open state in Scene 3 (panel expands below it, button stays visible above).</div>
+    <div class="note"><span class="pin">J</span>Zoom cluster from React Flow's <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, also tracks sidebar offset.</div>
 
-      <h3>Redesign hooks</h3>
-      <div class="note">Floating Kinds menu obscures the top-left of the canvas — could move into the sidebar.</div>
-      <div class="note">JSON panel and Kinds menu share the same surface but live on opposite corners — consider unifying as tabs.</div>
-      <div class="note">No persistent diagram title / breadcrumb on the canvas — currently only visible in the sidebar row.</div>
-      <div class="note">No surface for user identity / sign-out — sits implicitly behind the canvas.</div>
-    </aside>
+    <h3>Redesign hooks</h3>
+    <div class="note">Kinds menu and JSON panel both float over the canvas in opposite corners — could unify under a single right-side dock with tabs.</div>
+    <div class="note">No persistent diagram title / breadcrumb on the canvas — currently only visible in the sidebar row's active state.</div>
+    <div class="note">No user-identity / sign-out surface visible; lives implicitly behind the canvas.</div>
+    <div class="note">Sidebar holds search + list only — could grow to host the Kinds menu, layer toggles, or selection inspector.</div>
   </div>
 </section>
 
@@ -145,78 +179,109 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 2 — Kinds menu open</h2>
   <p class="lead">
-    User hovers the "Kinds ▾" button. Menu drops below the toolbar with one
-    row per shape kind plus orthogonal Points / Lines / Outlines toggles.
-    Hotkey hints in monospace at the right edge of each row.
+    Hovering the "Kinds" button reveals a glass dropdown 6 px below it.
+    Eight rows: five per-kind toggles (in registry order — Empties,
+    Triangles, Rhombuses, Circles, Rectangles) and three orthogonal toggles
+    (Points, Lines, Outlines). Each row is 5×10 padding, 11 px / 500 wt text;
+    on-state colours the dot accent-blue with a 3 px halo and brightens the
+    label to secondary; off rows stay dimmed.
   </p>
 
   <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
     <aside class="sidebar">
-      <div class="sidebar-brand"><span class="logo-mark"></span><span class="name">NeSyCat</span></div>
-      <div class="sidebar-search"><input placeholder="Search…" /><div class="plus">+</div></div>
+      <a class="sidebar-brand" href="#">
+        <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        <span class="brand-name">NeSyCat Semiotics</span>
+      </a>
+      <div class="sidebar-search-row">
+        <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
+        <button class="sidebar-new" type="button">+</button>
+      </div>
       <div class="sidebar-list">
-        <div class="diagram-row active"><span class="title">Untitled diagram</span><span class="meta">just now</span></div>
-        <div class="diagram-row"><span class="title">Categorical layer α</span><span class="meta">3h ago</span></div>
-        <div class="diagram-row"><span class="title">Logical 2Mon-BLat</span><span class="meta">yesterday</span></div>
-        <div class="diagram-row"><span class="title">Grammar substitution</span><span class="meta">2d ago</span></div>
+        <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
+        <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
+        <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+        <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
+        <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
       </div>
       <div class="sidebar-collapse">‹</div>
     </aside>
+
     <div class="canvas-area">
-      <div class="glass-bar toolbar-topleft">
-        <button class="glass-btn is-primary">Kinds ▴</button>
-        <div class="divider"></div>
-        <div class="toolbar-toggle">
-          <button class="glass-btn is-active">Straight</button>
-          <button class="glass-btn">Smooth</button>
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor">
+          <button class="panel-btn" type="button">Kinds</button>
+          <div class="kinds-menu">
+            <div class="panel">
+              <!-- Per-kind toggles in registry order (Canvas.tsx 651-653). -->
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Empties</span>
+                <span class="kbds"><span class="kbd">2×</span></span>
+              </div>
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Triangles</span>
+                <span class="kbds"><span class="kbd">Alt/⌥</span><span class="kbd">2×</span></span>
+              </div>
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Rhombuses</span>
+                <span class="kbds"><span class="kbd">⇧</span><span class="kbd">2×</span></span>
+              </div>
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Circles</span>
+                <span class="kbds"><span class="kbd">2×</span></span>
+              </div>
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Rectangles</span>
+                <span class="kbds"><span class="kbd">Ctrl/⌘</span><span class="kbd">2×</span></span>
+              </div>
+              <!-- Orthogonal toggles (Canvas.tsx 655-657). -->
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Points</span>
+                <span class="kbds"><span class="kbd">click +</span></span>
+              </div>
+              <div class="kind-row is-on">
+                <span class="dot"></span>
+                <span class="label">Lines</span>
+                <span class="kbds"><span class="kbd">drag ○→○</span></span>
+              </div>
+              <div class="kind-row">
+                <span class="dot"></span>
+                <span class="label">Outlines</span>
+              </div>
+            </div>
+          </div>
         </div>
+        <button class="panel-btn" type="button">Straight</button>
       </div>
 
-      <!-- Open Kinds menu -->
-      <div class="kinds-menu">
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Rectangles</span>
-          <span class="hint">⌘ 2×</span>
-        </div>
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Triangles</span>
-          <span class="hint">⌥ 2×</span>
-        </div>
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Rhombuses</span>
-          <span class="hint">⇧ 2×</span>
-        </div>
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Circles</span>
-          <span class="hint">2×</span>
-        </div>
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Empties</span>
-          <span class="hint">⌃ 2×</span>
-        </div>
-        <div class="divider"></div>
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Points</span>
-          <span class="hint">P</span>
-        </div>
-        <div class="row is-toggled">
-          <span class="name"><span class="check on"></span>Lines</span>
-          <span class="hint">L</span>
-        </div>
-        <div class="row">
-          <span class="name"><span class="check"></span>Outlines</span>
-          <span class="hint">O</span>
-        </div>
+      <div class="topright">
+        <button class="panel-btn" type="button">JSON</button>
       </div>
 
-      <div class="glass-bar json-panel-closed"><button class="glass-btn">JSON</button></div>
-      <div class="canvas-placeholder">
-        <div><strong>React Flow canvas — out of scope.</strong></div>
-      </div>
       <div class="controls-cluster">
-        <button>+</button><button>−</button><button>⊡</button><button>⤢</button>
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
     </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Menu structure (<code>Canvas.tsx</code> 646–660)</h3>
+    <div class="note"><span class="pin">K</span>Panel: <code>panelStyle()</code> + 8 px radius, 6×6 padding, <code>minWidth: 220</code>.</div>
+    <div class="note"><span class="pin">L</span>Rows iterate <code>geometryRegistry</code> — adding a kind in <code>types.ts</code> auto-extends this menu.</div>
+    <div class="note"><span class="pin">M</span>Dot: 6×6 circle, accent at 90% with a 3 px halo when on; transparent + 22% border when off.</div>
+    <div class="note"><span class="pin">N</span>Kbd chips: min-width 18, 18 px tall, 1 px glass border, 10 px Mono / 500 wt. Compound shortcuts use two chips side-by-side.</div>
+    <div class="note"><span class="pin">O</span>Outlines off here illustrates the off-state — dimmed label, hollow dot, no kbd hint.</div>
   </div>
 </section>
 
@@ -225,67 +290,109 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 3 — JSON panel open</h2>
   <p class="lead">
-    User clicked the JSON button. Top-right panel expands to ~320 × 280, with
-    an Export / Import header strip and a read-only code preview of the
-    diagram JSON beneath. Close on click-outside or button toggle.
+    JSON button toggles a 400-wide, 500-max-height glass panel. Header strip
+    carries a "DIAGRAM DATA" caption (11 px Mono / 600 wt / uppercase /
+    muted) plus Export / Import buttons. Body renders the diagram JSON in
+    10 px monospace at <code>rgba(0,0,0,0.25)</code> background.
   </p>
 
   <div class="editor-frame">
+    <div class="canvas-bg"></div>
+
     <aside class="sidebar">
-      <div class="sidebar-brand"><span class="logo-mark"></span><span class="name">NeSyCat</span></div>
-      <div class="sidebar-search"><input placeholder="Search…" /><div class="plus">+</div></div>
+      <a class="sidebar-brand" href="#">
+        <svg class="logo-mark"><use href="#logo-mark"/></svg>
+        <span class="brand-name">NeSyCat Semiotics</span>
+      </a>
+      <div class="sidebar-search-row">
+        <div class="sidebar-search"><input type="search" placeholder="Search…" /></div>
+        <button class="sidebar-new" type="button">+</button>
+      </div>
       <div class="sidebar-list">
-        <div class="diagram-row active"><span class="title">Untitled diagram</span><span class="meta">just now</span></div>
-        <div class="diagram-row"><span class="title">Categorical layer α</span><span class="meta">3h ago</span></div>
-        <div class="diagram-row"><span class="title">Logical 2Mon-BLat</span><span class="meta">yesterday</span></div>
+        <div class="diagram-row active"><span class="title">Mortimer&apos;s Thesis</span><span class="meta">2d ago</span></div>
+        <div class="diagram-row"><span class="title">CT for Programmers</span><span class="meta">2d ago</span></div>
+        <div class="diagram-row"><span class="title">Archetypon Logicon</span><span class="meta">3d ago</span></div>
+        <div class="diagram-row"><span class="title">PAZ CSG</span><span class="meta">3d ago</span></div>
+        <div class="diagram-row"><span class="title">PAZ Renderer types.py</span><span class="meta">3d ago</span></div>
       </div>
       <div class="sidebar-collapse">‹</div>
     </aside>
+
     <div class="canvas-area">
-      <div class="glass-bar toolbar-topleft">
-        <button class="glass-btn">Kinds ▾</button>
-        <div class="divider"></div>
-        <div class="toolbar-toggle">
-          <button class="glass-btn is-active">Straight</button>
-          <button class="glass-btn">Smooth</button>
+      <div class="toolbar-topleft">
+        <div class="kinds-anchor">
+          <button class="panel-btn" type="button">Kinds</button>
         </div>
+        <button class="panel-btn" type="button">Straight</button>
       </div>
 
-      <!-- Open JSON panel -->
-      <div class="glass-bar json-panel-open">
-        <div class="header">
-          <div class="left">
-            <button class="glass-btn">JSON ▴</button>
+      <div class="topright">
+        <button class="panel-btn" type="button">JSON</button>
+        <div class="json-panel">
+          <div class="header">
+            <span class="label">Diagram Data</span>
+            <div class="actions">
+              <button type="button">Export</button>
+              <button type="button">Import</button>
+            </div>
           </div>
-          <div>
-            <button class="glass-btn">Export ↓</button>
-            <button class="glass-btn">Import ↑</button>
-          </div>
-        </div>
-        <div class="body">{
+          <pre class="body">{
+  "schemaVersion": 1,
   "nodes": [
-    { "id": "S3", "kind": "empty", "points": {
-        "center": { "id": "P4", "name": "Y" }
-    } },
-    { "id": "S4", "kind": "rectangle", "points": {
-        "left":  { "center": [ { "id": "P6", "name": "Y" } ] },
-        "right": { "center": [ { "id": "P7", "name": "H1" } ] }
-    } }
-  ],
-  "edges": [
-    { "id": "L1", "name": "L1", "source": "P4", "targets": ["P6"] },
-    { "id": "L2", "name": "L2", "source": "P7", "targets": ["P8"] }
+    {
+      "id": "S3",
+      "points": {
+        "center": {
+          "id": "P4",
+          "name": "Y",
+          "points": {},
+          "kind": "empty",
+          "order": 0,
+          "color": [
+            0.23137254901960785,
+            0.5098039215686274,
+            0.9647058823529412
+          ],
+          "transform": {
+            "time": {
+              "created": 1778342045963,
+              "updated": 1778342045963
+            },
+            "space": {
+              "scale": [
+                1,
+                1
+              ],
+              "rotation": 0,
+              "translation": [
+                0,
+                0
+              ]
+            }
+          }
+        }
+      }
+    }
   ]
-}</div>
+}</pre>
+        </div>
       </div>
 
-      <div class="canvas-placeholder">
-        <div><strong>React Flow canvas — out of scope.</strong></div>
-      </div>
       <div class="controls-cluster">
-        <button>+</button><button>−</button><button>⊡</button><button>⤢</button>
+        <button type="button"><svg><use href="#ic-plus"/></svg></button>
+        <button type="button"><svg><use href="#ic-minus"/></svg></button>
+        <button type="button"><svg><use href="#ic-fit"/></svg></button>
+        <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
     </div>
+  </div>
+
+  <div class="annotations">
+    <h3>Panel (<code>Canvas.tsx</code> 680–710)</h3>
+    <div class="note"><span class="pin">P</span>Width 400, max-height 500, glass panel + 8 px radius. Header strip border-bottom glass-border.</div>
+    <div class="note"><span class="pin">Q</span>Caption: "DIAGRAM DATA" — 11 px Mono / 600 wt / uppercase / muted, 0.05em letter-spacing.</div>
+    <div class="note"><span class="pin">R</span>Export / Import: glass buttons, 4 px radius, 11 px / 2×10 padding. Import opens a hidden file input.</div>
+    <div class="note"><span class="pin">S</span>Body <code>&lt;pre&gt;</code>: <code>rgba(0,0,0,0.25)</code> bg, 12 px padding, 10 px Mono, line-height 1.4, scrollable.</div>
   </div>
 </section>
 
@@ -294,10 +401,9 @@
 <section class="wireframe-section">
   <h2 class="t-h1">Scene 4 — Star-prompt modal</h2>
   <p class="lead">
-    After ~45s idle, a full-screen modal asks the user to star the GitHub
-    repo. Dismissible with "Not now" (snoozes 3 days) or "Star on GitHub"
-    (opens repo). Shown here as a stand-alone state since it overlays any of
-    the scenes above.
+    After ~45 s idle, a full-screen modal asks the user to star the GitHub
+    repo. 50% dark scrim over the editor, body centred at ~420 px wide.
+    Dismiss with "Not now" (snooze 3 days) or "Star on GitHub" (opens repo).
   </p>
 
   <div class="modal-frame">
@@ -309,8 +415,8 @@
           A star on GitHub helps other category-theoretic AI folks find the project.
         </p>
         <div class="btn-row">
-          <button class="btn">Not now</button>
-          <button class="btn is-primary">Star on GitHub ↗</button>
+          <button class="btn" type="button">Not now</button>
+          <button class="btn is-primary" type="button">Star on GitHub ↗</button>
         </div>
       </div>
     </div>
@@ -319,11 +425,10 @@
 
 <footer class="wireframe-section" style="border-bottom: none">
   <p class="t-small" style="color: var(--color-text-dimmed)">
-    Out of scope for this wireframe: the React Flow canvas itself (node /
-    point / line rendering), the inline rename input that appears on
-    double-clicking a point name, the slot <code>+</code> buttons that appear
-    when a shape is selected. Those live inside the canvas and belong to a
-    separate redesign pass.
+    Out of scope: the React Flow canvas itself (node / point / line rendering),
+    the inline rename input on double-clicking a point name, the slot
+    <code>+</code> buttons that surface when a shape is selected. Those live
+    inside the canvas and belong to a separate redesign pass.
   </p>
 </footer>
 

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -51,9 +51,10 @@
     </symbol>
 
     <!--
-      Shape-spine tool-rail icons. Each maps 1:1 to a user-facing field of
-      `Shape<K>` in components/editor/types.ts (lines 116-126). viewBox is 24×24 so the
-      rail's 18×18 rendering keeps a 3 px optical inset on each side.
+      Shape-spine tool-button icons (live inside the .editor-topbar). Each
+      maps 1:1 to a user-facing field of `Shape<K>` in
+      components/editor/types.ts (lines 116-126). viewBox is 24×24 so the
+      18×18 rendering keeps a 3 px optical inset on each side.
     -->
     <!-- name — Geist “A”; fill/font on <text> so &lt;use&gt; shadow tree still paints (CSS won’t target cloned nodes). -->
     <symbol id="ic-name" viewBox="0 0 24 24">
@@ -156,18 +157,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"       type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"     type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"       type="button" aria-label="Kind"      title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"      type="button" aria-label="Order"     title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color" type="button" aria-label="Color" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"  type="button" aria-label="Transform" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"  type="button" aria-label="Equations" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"     type="button" aria-label="Weight"    title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"       type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"     type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"       type="button" aria-label="Kind"      title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"      type="button" aria-label="Order"     title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color" type="button" aria-label="Color" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"  type="button" aria-label="Transform" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"  type="button" aria-label="Equations" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"     type="button" aria-label="Weight"    title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -233,18 +234,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name is-active" type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"           type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"          type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"          type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"      type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"      type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"         type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name is-active" type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"           type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"          type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"          type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"      type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"      type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"         type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -305,18 +306,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points is-active" type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"             type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"            type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"            type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"        type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"        type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"           type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points is-active" type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"             type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"            type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"            type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"        type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"        type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"           type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -378,18 +379,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"           type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind is-active" type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"          type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"          type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"      type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"      type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"         type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"           type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"         type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind is-active" type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"          type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"          type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"      type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"      type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"         type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -513,18 +514,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"            type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order is-active" type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"           type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"       type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"       type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"          type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"            type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order is-active" type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"           type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"       type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"       type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"          type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -599,18 +600,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"            type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"           type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color is-active" type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"       type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"       type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"          type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"            type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"          type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"            type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"           type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color is-active" type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"       type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"       type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"          type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -734,18 +735,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"                type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"               type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"               type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform is-active" type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"           type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"              type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"                type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"               type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"               type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform is-active" type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"           type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"              type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -824,18 +825,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"                type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"               type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"               type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"           type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations is-active" type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"              type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"                type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"              type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"                type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"               type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"               type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"           type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations is-active" type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"              type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -856,7 +857,7 @@
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Equations</span>
-          <button type="button" class="sidebar-tool eq-popover-add" title="Add equation" aria-label="Add equation">
+          <button type="button" class="shape-tool eq-popover-add" title="Add equation" aria-label="Add equation">
             <svg><use href="#ic-plus"/></svg>
           </button>
         </div>
@@ -901,18 +902,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"           type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"             type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"            type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"            type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform"        type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations"        type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight is-active" type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"             type="button" title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"           type="button" title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"             type="button" title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"            type="button" title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"            type="button" title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform"        type="button" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations"        type="button" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight is-active" type="button" title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
+        <button type="button" class="shape-tool topbar-share" title="Export or share diagram data" aria-label="Share or export diagram">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>
@@ -987,18 +988,18 @@
       </div>
       <div class="topbar-center">
         <div class="topbar-tools" role="toolbar" aria-label="Shape editor">
-          <button class="sidebar-tool tool-name"      type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
-          <button class="sidebar-tool tool-points"    type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
-          <button class="sidebar-tool tool-kind"      type="button" aria-label="Kind"      title="Kind"><svg><use href="#ic-kind"/></svg></button>
-          <button class="sidebar-tool tool-order"     type="button" aria-label="Order"     title="Order"><svg><use href="#ic-order"/></svg></button>
-          <button class="sidebar-tool tool-color"     type="button" aria-label="Color"     title="Color"><svg><use href="#ic-color"/></svg></button>
-          <button class="sidebar-tool tool-transform" type="button" aria-label="Transform" title="Transform"><svg><use href="#ic-transform"/></svg></button>
-          <button class="sidebar-tool tool-equations" type="button" aria-label="Equations" title="Equations"><svg><use href="#ic-equations"/></svg></button>
-          <button class="sidebar-tool tool-weight"    type="button" aria-label="Weight"    title="Weight"><svg><use href="#ic-weight"/></svg></button>
+          <button class="shape-tool tool-name"      type="button" aria-label="Name"      title="Name"><svg><use href="#ic-name"/></svg></button>
+          <button class="shape-tool tool-points"    type="button" aria-label="Points"    title="Points"><svg><use href="#ic-points"/></svg></button>
+          <button class="shape-tool tool-kind"      type="button" aria-label="Kind"      title="Kind"><svg><use href="#ic-kind"/></svg></button>
+          <button class="shape-tool tool-order"     type="button" aria-label="Order"     title="Order"><svg><use href="#ic-order"/></svg></button>
+          <button class="shape-tool tool-color"     type="button" aria-label="Color"     title="Color"><svg><use href="#ic-color"/></svg></button>
+          <button class="shape-tool tool-transform" type="button" aria-label="Transform" title="Transform"><svg><use href="#ic-transform"/></svg></button>
+          <button class="shape-tool tool-equations" type="button" aria-label="Equations" title="Equations"><svg><use href="#ic-equations"/></svg></button>
+          <button class="shape-tool tool-weight"    type="button" aria-label="Weight"    title="Weight"><svg><use href="#ic-weight"/></svg></button>
         </div>
       </div>
       <div class="topbar-actions">
-        <button type="button" class="sidebar-tool topbar-share is-panel-open" title="Export or share diagram data" aria-label="Share or export diagram" aria-expanded="true">
+        <button type="button" class="shape-tool topbar-share is-panel-open" title="Export or share diagram data" aria-label="Share or export diagram" aria-expanded="true">
           <svg><use href="#ic-share"/></svg>
         </button>
       </div>

--- a/_design/02-wireframe/index.html
+++ b/_design/02-wireframe/index.html
@@ -16,11 +16,14 @@
 <svg width="0" height="0" style="position: absolute" aria-hidden="true">
   <defs>
     <symbol id="logo-mark" viewBox="0 0 24 24">
+      <!-- Stroke / fill resolved via currentColor on use site; default is the accent. -->
       <rect x="2" y="2" width="20" height="20"
-            fill="rgba(59,130,246,0.1)" stroke="rgb(59,130,246)" stroke-width="1.3" />
+            fill="rgba(var(--color-accent-rgb), 0.1)"
+            stroke="rgb(var(--color-accent-rgb))" stroke-width="1.3" />
       <polygon points="12,3 21,12 12,21 3,12"
-               fill="rgba(59,130,246,0.25)" stroke="rgb(59,130,246)" stroke-width="1.3" />
-      <circle cx="12" cy="12" r="2.2" fill="rgb(59,130,246)" />
+               fill="rgba(var(--color-accent-rgb), 0.25)"
+               stroke="rgb(var(--color-accent-rgb))" stroke-width="1.3" />
+      <circle cx="12" cy="12" r="2.2" fill="rgb(var(--color-accent-rgb))" />
     </symbol>
     <!-- Zoom-control icons (match React Flow's <Controls />). -->
     <symbol id="ic-plus" viewBox="0 0 24 24">
@@ -119,7 +122,7 @@
 </svg>
 
 <header class="page-header">
-  <div class="t-caption">NeSyCat · Wireframe · v0.5 · 1728×1080 (16″ MBP scaled)</div>
+  <div class="t-caption">NeSyCat · Wireframe · v0.6 · 1728×1080 (16″ MBP scaled)</div>
   <h1 class="t-h1">Editor chrome — pixel-faithful to today.</h1>
   <p>
     Each scene is a 1728×1080 frame sized for a 16″ MacBook Pro at default
@@ -199,9 +202,8 @@
     <div class="note"><span class="pin">J</span>The internal-only <code>id</code> field has no rail button — <code>types.ts:29</code>: "Auto-generated, unique, internal — never user-facing."</div>
     <div class="note"><span class="pin">K</span>Buttons 40×40, 6 px radius. Active state tinted with <code>rgba(accent, 0.18)</code> + accent border. Hover swaps to glass-button bg + glass border.</div>
     <h3>Canvas chrome (<code>Canvas.tsx</code>)</h3>
-    <div class="note"><span class="pin">L</span>Share control in the top bar opens export / diagram data (panel open in Scene 13). Zoom controls bottom-left.</div>
-    <div class="note"><span class="pin">P</span>Share control; open state in Scene 13 (diagram-data panel drops below the bar on the right).</div>
-    <div class="note"><span class="pin">Q</span>Zoom cluster from React Flow <code>&lt;Controls/&gt;</code>: 28 px buttons stacked.</div>
+    <div class="note"><span class="pin">L</span>Share control opens export / diagram data — open state in Scene 13 (panel drops below the bar on the right).</div>
+    <div class="note"><span class="pin">M</span>Zoom cluster from React Flow <code>&lt;Controls/&gt;</code>: 28 px buttons stacked, bottom-left.</div>
 
     <h3>Redesign hooks</h3>
     <div class="note">File management (search, diagram list, +new) needs a new home — likely a separate picker / file-tree surface, opened via the logo or a dedicated chrome button.</div>
@@ -216,11 +218,11 @@
   <h2 class="t-h1">Scene 5 — name popover</h2>
   <p class="lead">
     Clicking the <code>name</code> button opens a popover below the top bar,
-    aligned with that tool. The header row carries the panel
-    title and the 3-state visibility icons (Off · Selected · All); the body
-    holds the editor. Rename today happens inline (double-click
-    on the canvas, <code>DiagramNode.tsx:360-448</code>); the input here is
-    a faster alternative when the shape is already selected.
+    aligned with that tool. The head carries the title and a binary
+    visibility dot (click to hide name labels on the canvas); the body
+    holds the editor. Rename today happens inline (double-click on the
+    canvas, <code>DiagramNode.tsx:360-448</code>); the input here is a
+    faster alternative when the shape is already selected.
   </p>
 
   <div class="editor-frame">
@@ -259,10 +261,10 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the name button (cluster left + i×46). -->
-      <div class="tool-popover" style="left: 683px; width: 280px">
+      <!-- Popover anchored to the name button (i=0). -->
+      <div class="tool-popover" style="--tool-index: 0; width: 280px">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Name</span>
@@ -278,7 +280,7 @@
     <h3>Source of truth</h3>
     <div class="note"><span class="pin">A</span><code>Shape.name?: string</code> at <code>types.ts:118</code> — only set on labeled leaves.</div>
     <div class="note"><span class="pin">B</span>Today's UI: inline rename via <code>DiagramNode.tsx:360-448</code>. No popover yet.</div>
-    <div class="note"><span class="pin">C</span><code>Off</code> globally hides name labels; <code>Selected</code> shows the label only on the active selection; <code>All</code> = today's behaviour.</div>
+    <div class="note"><span class="pin">C</span>Visibility dot in the head toggles name labels on the canvas (binary — today's behaviour vs hidden).</div>
   </div>
 </section>
 
@@ -290,9 +292,9 @@
     The <code>points</code> popover is visibility-first — there's no
     editor for the nested-shape tree itself; points are added via the
     <code>+</code> buttons that surface on a selected shape
-    (<code>DiagramNode.tsx:514-537</code>). Today's
-    <code>visibility.points</code> flag maps to "All" / "Off"; the
-    new "Selected" middle step shows handles only on the active shape.
+    (<code>DiagramNode.tsx:514-537</code>). The head's binary visibility
+    dot toggles today's <code>visibility.points</code> flag
+    (<code>store.ts:8</code>).
   </p>
 
   <div class="editor-frame">
@@ -331,10 +333,10 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the points button. -->
-      <div class="tool-popover tool-popover--tight" style="left: 729px">
+      <!-- Popover anchored to the points button (i=1). -->
+      <div class="tool-popover tool-popover--tight" style="--tool-index: 1">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Points</span>
@@ -347,7 +349,7 @@
     <h3>Source of truth</h3>
     <div class="note"><span class="pin">A</span><code>Shape.points: ShapePoints[K]</code> at <code>types.ts:119</code> — recursive sub-shape tree; branching shape differs per <code>ShapeKind</code>.</div>
     <div class="note"><span class="pin">B</span>Today: <code>visibility.points</code> in <code>store.ts:8</code>; CSS gate <code>.points-hidden .point-label</code> in <code>app/globals.css</code>.</div>
-    <div class="note"><span class="pin">C</span>"Selected" is the new middle step — shows handles only on the active shape.</div>
+    <div class="note"><span class="pin">C</span>Same dot chrome as the panel head — click to hide / show point handles globally.</div>
   </div>
 </section>
 
@@ -409,9 +411,9 @@
            Line<K> extends Shape<K> and uses the same kind field — not a sixth ShapeKind (types.ts:137-148).
            Layout: one horizontal strip — one column per ShapeKind (visibility dot above drag tile).
            Header strip: panel-level visibility toggle; each column has the same toggle chrome per kind. -->
-      <div class="tool-popover" style="left: 775px; width: max-content; min-width: 0">
+      <div class="tool-popover" style="--tool-index: 2; width: max-content; min-width: 0">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Panel visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Panel visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Kind</span>
@@ -539,17 +541,17 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the order button (i=3, top 198). -->
-      <div class="tool-popover" style="left: 821px; width: 280px">
+      <!-- Popover anchored to the order button (i=3). -->
+      <div class="tool-popover" style="--tool-index: 3; width: 280px">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Order</span>
         </div>
         <div class="body">
           <div class="order-value-row">
-            <input class="num-input" type="text" value="2" aria-label="Order value" />
+            <input class="num-input" type="text" inputmode="numeric" value="2" aria-label="Order value" />
             <div class="slider-col slider-col--horizontal">
               <div class="slider-stack">
               <div class="slider-track">
@@ -625,10 +627,10 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the color button (i=4, top 244). -->
-      <div class="tool-popover tool-popover--color" style="left: 867px; width: 296px">
+      <!-- Popover anchored to the color button (i=4). -->
+      <div class="tool-popover tool-popover--color" style="--tool-index: 4; width: 296px">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Color</span>
@@ -679,7 +681,7 @@
           </div>
           <span class="body-label">Swatches</span>
           <div class="swatches">
-            <div class="sw" style="background:rgb(59,130,246)"></div>
+            <div class="sw" style="background:var(--color-accent-blue)"></div>
             <div class="sw" style="background:rgb(99, 157, 255)"></div>
             <div class="sw" style="background:rgb(155, 89, 235)"></div>
             <div class="sw" style="background:rgb(236, 72, 153)"></div>
@@ -707,7 +709,7 @@
     <h3>Source of truth</h3>
     <div class="note"><span class="pin">A</span><code>Shape.color: Color</code> at <code>types.ts:122</code>; <code>Color = [r, g, b] ∈ [0, 1]³</code> at <code>types.ts:79</code>.</div>
     <div class="note"><span class="pin">B</span>Today: no picker. Shapes init to <code>DEFAULT_COLOR</code> from <code>color.ts:5</code> (same as <code>--color-accent-rgb</code>).</div>
-    <div class="note"><span class="pin">C</span><code>Off</code> renders shapes monochrome (outlines only); <code>Selected</code> tints the selection alone; <code>All</code> matches today.</div>
+    <div class="note"><span class="pin">C</span>Visibility dot toggles colored fill on the canvas; off renders shapes monochrome (outlines only).</div>
   </div>
 </section>
 
@@ -760,10 +762,10 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the transform button (i=5, top 290). -->
-      <div class="tool-popover" style="left: 913px; width: 296px">
+      <!-- Popover anchored to the transform button (i=5). -->
+      <div class="tool-popover" style="--tool-index: 5; width: 296px">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Transform</span>
@@ -772,21 +774,21 @@
           <div class="transform-row">
             <span class="transform-row-name">Scale</span>
             <div class="transform-row-fields">
-              <div class="transform-field"><span class="transform-field-label">sx</span><input class="num-input" type="text" value="1.00" aria-label="Scale x" /></div>
-              <div class="transform-field"><span class="transform-field-label">sy</span><input class="num-input" type="text" value="1.00" aria-label="Scale y" /></div>
+              <div class="transform-field"><span class="transform-field-label">sx</span><input class="num-input" type="text" inputmode="numeric" value="1.00" aria-label="Scale x" /></div>
+              <div class="transform-field"><span class="transform-field-label">sy</span><input class="num-input" type="text" inputmode="numeric" value="1.00" aria-label="Scale y" /></div>
             </div>
           </div>
           <div class="transform-row">
             <span class="transform-row-name">Translate</span>
             <div class="transform-row-fields">
-              <div class="transform-field"><span class="transform-field-label">tx</span><input class="num-input" type="text" value="120" aria-label="Translate x" /></div>
-              <div class="transform-field"><span class="transform-field-label">ty</span><input class="num-input" type="text" value="-40" aria-label="Translate y" /></div>
+              <div class="transform-field"><span class="transform-field-label">tx</span><input class="num-input" type="text" inputmode="numeric" value="120" aria-label="Translate x" /></div>
+              <div class="transform-field"><span class="transform-field-label">ty</span><input class="num-input" type="text" inputmode="numeric" value="-40" aria-label="Translate y" /></div>
             </div>
           </div>
           <div class="transform-row">
             <span class="transform-row-name">Rotate</span>
             <div class="transform-row-fields">
-              <div class="transform-field"><span class="transform-field-label">θ</span><input class="num-input" type="text" value="0°" aria-label="Rotation" /></div>
+              <div class="transform-field"><span class="transform-field-label">θ</span><input class="num-input" type="text" inputmode="numeric" value="0°" aria-label="Rotation" /></div>
             </div>
           </div>
         </div>
@@ -798,7 +800,7 @@
     <h3>Source of truth</h3>
     <div class="note"><span class="pin">A</span><code>Shape.transform: SpaceTime</code> at <code>types.ts:123</code>; <code>Space</code> + <code>Time</code> at <code>types.ts:86-92</code>.</div>
     <div class="note"><span class="pin">B</span>Today: only translation editable. Rotation / scale fields exist but no UI.</div>
-    <div class="note"><span class="pin">C</span>Visibility "Selected" shows transform handles only on the active selection — useful when many shapes overlap.</div>
+    <div class="note"><span class="pin">C</span>Visibility dot toggles whether rotation / scale handles are drawn on the canvas (binary; off keeps drag-translation only).</div>
   </div>
 </section>
 
@@ -850,10 +852,10 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the equations button (i=6, top 336). -->
-      <div class="tool-popover tool-popover--equations" style="left: 959px; width: 352px">
+      <!-- Popover anchored to the equations button (i=6). -->
+      <div class="tool-popover tool-popover--equations" style="--tool-index: 6; width: 352px">
         <div class="head">
-          <button type="button" class="head-vis-toggle is-on" aria-label="Visibility" aria-pressed="true">
+          <button type="button" class="head-vis-toggle is-on is-compact" aria-label="Visibility" aria-pressed="true">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Equations</span>
@@ -927,10 +929,10 @@
         <button type="button"><svg><use href="#ic-lock"/></svg></button>
       </div>
 
-      <!-- Popover anchored to the weight button (i=7, top 382). -->
-      <div class="tool-popover" style="left: 1005px; width: 280px">
+      <!-- Popover anchored to the weight button (i=7). -->
+      <div class="tool-popover" style="--tool-index: 7; width: 280px">
         <div class="head">
-          <button type="button" class="head-vis-toggle" aria-label="Visibility" aria-pressed="false">
+          <button type="button" class="head-vis-toggle is-compact" aria-label="Visibility" aria-pressed="false">
             <span class="head-vis-dot" aria-hidden="true"></span>
           </button>
           <span class="head-title">Weight</span>
@@ -939,7 +941,7 @@
           <div class="slider-col slider-col--weight">
             <div class="weight-slider-controls">
               <div class="weight-num-row">
-                <input class="num-input" type="text" value="1.0" aria-label="Weight value" />
+                <input class="num-input" type="text" inputmode="numeric" value="1.0" aria-label="Weight value" />
               </div>
               <div class="slider-stack">
                 <div class="slider-track">
@@ -1069,10 +1071,10 @@
 
   <div class="annotations">
     <h3>Panel (<code>Canvas.tsx</code> 680–710)</h3>
-    <div class="note"><span class="pin">P</span>Same <code>.tool-popover</code> as shape popovers; instance <code>style</code> sets width 400 and max-height 500.</div>
-    <div class="note"><span class="pin">Q</span>Caption uses <code>.head-title</code> (shared with Weight, etc.).</div>
-    <div class="note"><span class="pin">R</span>Export / Import: <code>.head .actions button</code> — light text buttons, shared rule with all diagram-data popovers.</div>
-    <div class="note"><span class="pin">S</span>JSON: <code>.body &gt; pre</code> — mono 10px, scroll; no separate panel bg (inherits <code>--color-glass-panel-bg</code>).</div>
+    <div class="note"><span class="pin">A</span>Same <code>.tool-popover</code> as shape popovers; instance <code>style</code> sets width 400 and max-height 500.</div>
+    <div class="note"><span class="pin">B</span>Caption uses <code>.head-title</code> (shared with Weight, etc.).</div>
+    <div class="note"><span class="pin">C</span>Export / Import: <code>.head .actions button</code> — light text buttons, shared rule with all diagram-data popovers.</div>
+    <div class="note"><span class="pin">D</span>JSON: <code>.body &gt; pre</code> — mono 10px, scroll; no separate panel bg (inherits <code>--color-glass-panel-bg</code>).</div>
   </div>
 </section>
 

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -6,13 +6,14 @@
  * 1728 × 1117 effective points. Each scene frame is 1728 × 1080 to mirror
  * the real viewport once the macOS chrome is removed.
  *
- * Token + styling sources cited inline next to each rule:
- *   Top bar (shape tools + share)     — replaces left rail in this wireframe
- *   Canvas.tsx (Kinds toolbar)  — top-left
- *   Canvas.tsx (KindRow + Kbd)  — Kinds menu
- *   Canvas.tsx (diagram data panel) — reuse `.tool-popover`
- *   ReactFlow <Controls/>       — bottom-left zoom cluster
- *   ../00-design-system/tokens.css — colours + typography
+ * Region map:
+ *   .editor-topbar          — logo · shape-tool strip · share (top, 52 px)
+ *   .canvas-area            — full-width host below the bar
+ *   .tool-popover           — shared shell for shape inspector + diagram-data
+ *   .controls-cluster       — bottom-left zoom buttons (matches React Flow <Controls/>)
+ *   .modal-frame            — separate frame for the star-prompt scene
+ *
+ * Tokens come from ../00-design-system/tokens.css.
  */
 
 @import url("../00-design-system/tokens.css");
@@ -63,13 +64,11 @@ body {
  *     <main className="absolute inset-0">{Canvas}</main>
  *     <EditorSidebar diagrams={diagrams} />
  *   </div>
- * Width fixed at 1728, height 1080, no scrollbars. CSS var
- * `--sidebar-offset` is 0 (top bar only; rail removed from this wireframe).
+ * Width fixed at 1728, height 1080, no scrollbars.
  * `--editor-topbar-height` reserves space for the horizontal tool strip + share.
  */
 
 .editor-frame {
-  --sidebar-offset: 0px;
   --editor-topbar-height: 52px;
   position: relative;
   width: 1728px;
@@ -176,38 +175,38 @@ body {
   flex: 0 0 auto;
   z-index: 1;
 }
-/* Share uses .sidebar-tool (same 40×40, radius 6, hover/focus chrome as shape tools). */
-.sidebar-tool.topbar-share.is-panel-open {
+/* Share uses .shape-tool (same 40×40, radius 6, hover/focus chrome as shape tools). */
+.shape-tool.topbar-share.is-panel-open {
   background: rgba(var(--color-accent-rgb), 0.18);
   border-color: rgba(var(--color-accent-rgb), 0.5);
   color: var(--color-text-primary);
 }
-.editor-topbar .sidebar-tool {
+.editor-topbar .shape-tool {
   flex-shrink: 0;
 }
-/* Match .topbar-brand:hover — subtle fill, no glass border ring (sidebar rail keeps glass hover). */
-.editor-topbar .sidebar-tool:hover {
+/* Match .topbar-brand:hover — subtle fill, no glass border ring. */
+.editor-topbar .shape-tool:hover {
   background: rgba(255, 255, 255, 0.05);
   border-color: transparent;
   color: var(--color-text-muted);
 }
-.editor-topbar .sidebar-tool.is-active:hover {
+.editor-topbar .shape-tool.is-active:hover {
   background: rgba(var(--color-accent-rgb), 0.22);
   border-color: rgba(var(--color-accent-rgb), 0.55);
   color: var(--color-text-primary);
 }
-.editor-topbar .sidebar-tool.topbar-share.is-panel-open:hover {
+.editor-topbar .shape-tool.topbar-share.is-panel-open:hover {
   background: rgba(var(--color-accent-rgb), 0.25);
   border-color: rgba(var(--color-accent-rgb), 0.55);
   color: var(--color-text-primary);
 }
 
-/* ───────── Left sidebar (reference / vertical mock only — not used in frames) ─────────
+/* ───────── Shape-spine tool buttons (live inside .editor-topbar) ─────────
  *
- * 56-wide vertical rail. Buttons mirror user-facing fields of `Shape<K>`
- * in components/editor/types.ts (lines 116-126), in declaration order:
+ * One button per user-facing field of `Shape<K>` in
+ * components/editor/types.ts (lines 116-126), in declaration order:
  *
- *   name        → tool-name        — Geist “A” (label)
+ *   name        → tool-name        — Geist "A" (label)
  *   points      → tool-points      — two dots, wider spacing
  *   kind        → tool-kind        — triangle (representative kind)
  *   order       → tool-order       — three ascending bars
@@ -217,54 +216,12 @@ body {
  *   weight      → tool-weight      — kettlebell glyph
  *
  * Internal-only `id` (types.ts:29) has no button.
- * File-management (search / +new / diagram list) moves out of the sidebar;
- * picker lives elsewhere in a later iteration.
  */
-
-.sidebar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 56px;
-  background: var(--color-glass-panel-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  border-right: 1px solid var(--color-glass-border);
-  display: flex;
-  flex-direction: column;
-  z-index: 2;
-  overflow: hidden;
-}
-.sidebar > .sidebar-inner {
-  width: 56px;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Logo at top — icon only, no brand text. */
-.sidebar-brand {
-  display: grid;
-  place-items: center;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--color-glass-border);
-  text-decoration: none;
-}
-.sidebar-brand:hover { background: rgba(255, 255, 255, 0.05); }
 
 /* Inline SVG logo mark (matches LogoMark in EditorSidebar.tsx). */
 .logo-mark { width: 22px; height: 22px; flex-shrink: 0; }
 
-/* Tool list — vertically stacked icon buttons, one per editable Shape field. */
-.sidebar-tools {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 0;
-}
-.sidebar-tool {
+.shape-tool {
   width: 40px;
   height: 40px;
   display: grid;
@@ -277,17 +234,17 @@ body {
   padding: 0;
   position: relative;
 }
-.sidebar-tool:hover {
+.shape-tool:hover {
   background: var(--color-glass-button-bg);
   border-color: var(--color-glass-border);
   color: var(--color-text-secondary);
 }
-.sidebar-tool.is-active {
+.shape-tool.is-active {
   background: rgba(var(--color-accent-rgb), 0.18);
   border-color: rgba(var(--color-accent-rgb), 0.5);
   color: var(--color-text-primary);
 }
-.sidebar-tool svg {
+.shape-tool svg {
   width: 18px;
   height: 18px;
   fill: none;
@@ -296,24 +253,22 @@ body {
   stroke-linecap: round;
   stroke-linejoin: round;
 }
-/* `tool-color`'s glyph IS the color — render it as a filled disk in the
-   shape's current color (default accent), no stroke. */
-.sidebar-tool.tool-color svg {
+/* `tool-color`'s glyph IS the color — filled disk in current shape color. */
+.shape-tool.tool-color svg {
   fill: var(--color-accent-blue);
   stroke: rgba(255, 255, 255, 0.45);
   stroke-width: 1;
 }
-/* `tool-name` — letterform inside <use>; avoid fill:none from .sidebar-tool svg leaking via inheritance. */
-.sidebar-tool.tool-name svg {
+/* `tool-name` — letterform; cancel the fill:none / stroke base. */
+.shape-tool.tool-name svg {
   width: 20px;
   height: 20px;
   stroke: none;
   fill: currentColor;
 }
-
 /* `tool-points` and `tool-equations` glyphs read better as filled shapes. */
-.sidebar-tool.tool-points svg,
-.sidebar-tool.tool-equations svg {
+.shape-tool.tool-points svg,
+.shape-tool.tool-equations svg {
   fill: currentColor;
   stroke: none;
 }
@@ -329,131 +284,9 @@ body {
   z-index: 1;
 }
 
-/* ───────── Top-left toolbar (Kinds + Straight) ───────── */
-/*
- * position: absolute; top: 12; left: calc(12 + var(--sidebar-offset));
- * display: flex; gap: 8; align-items: flex-start.
- * Each button uses panelStyle() + borderRadius 8 + padding 6px 14px,
- * 12px / 600wt / secondary text.
- */
-
-.toolbar-topleft {
-  position: absolute;
-  top: calc(12px + var(--editor-topbar-height));
-  left: 12px;
-  z-index: 10;
-  display: flex;
-  gap: 8px;
-  align-items: flex-start;
-}
-
-.panel-btn {
-  background: var(--color-glass-panel-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  border: 1px solid var(--color-glass-border);
-  border-radius: 8px;
-  padding: 6px 14px;
-  font-family: var(--font-geist-sans);
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-/* Kinds button + its drop-down container */
-.kinds-anchor {
-  position: relative;
-}
-.kinds-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  padding-top: 6px;          /* gap from button (matches Canvas.tsx: paddingTop: 6) */
-  z-index: 10;
-}
-.kinds-menu .panel {
-  background: var(--color-glass-panel-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  border: 1px solid var(--color-glass-border);
-  border-radius: 8px;
-  padding: 6px 6px;
-  min-width: 220px;
-}
-/* KindRow — Canvas.tsx 730-755 (scoped: only the mock “Kinds” dropdown, not the Kind popover list) */
-.kinds-menu .kind-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--color-text-dimmed);
-  cursor: pointer;
-  user-select: none;
-}
-.kinds-menu .kind-row.is-on  { color: var(--color-text-secondary); }
-.kinds-menu .kind-row:hover  { background: rgba(255, 255, 255, 0.04); }
-.kinds-menu .kind-row .dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: transparent;
-  margin-left: 2px;
-  flex-shrink: 0;
-}
-.kinds-menu .kind-row.is-on .dot {
-  background: rgba(var(--color-accent-rgb), 0.9);
-  border-color: transparent;
-  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
-}
-.kinds-menu .kind-row .label { flex: 1; }
-.kinds-menu .kind-row .kbds {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-}
-/* Kbd — Canvas.tsx 715-727 */
-.kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border: 1px solid var(--color-glass-border);
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--color-text-secondary);
-  font-family: var(--font-geist-mono);
-  font-size: 10px;
-  font-weight: 500;
-  line-height: 1;
-  letter-spacing: 0;
-  white-space: nowrap;
-}
-
-/* ───────── `.topright` — anchor hook for future chrome (unused in current wireframe HTML). ───────── */
-
-.topright {
-  position: absolute;
-  top: calc(12px + var(--editor-topbar-height));
-  right: 12px;
-  z-index: 10;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: flex-end;
-}
-
 /* ───────── Bottom-left zoom controls (React Flow <Controls />) ─────────
  * Styled in app/globals.css .react-flow__controls: glass panel, 28x28
- * buttons stacked vertically, glass-border between; left inset uses --sidebar-offset.
+ * buttons stacked vertically, glass-border between.
  */
 
 .controls-cluster {
@@ -1301,17 +1134,17 @@ code {
   flex: 1;
   min-width: 0;
 }
-/* Compact “+”: same accent treatment as active .sidebar-tool, not 40×40. */
-.tool-popover--equations .head .eq-popover-add.sidebar-tool {
+/* Compact “+”: same accent treatment as active .shape-tool, not 40×40. */
+.tool-popover--equations .head .eq-popover-add.shape-tool {
   width: 28px;
   height: 28px;
   flex-shrink: 0;
 }
-.tool-popover--equations .head .eq-popover-add.sidebar-tool svg {
+.tool-popover--equations .head .eq-popover-add.shape-tool svg {
   width: 14px;
   height: 14px;
 }
-/* Match default + hover chrome of .editor-topbar .sidebar-tool (e.g. Weight when inactive). */
+/* Match default + hover chrome of .editor-topbar .shape-tool (e.g. Weight when inactive). */
 .tool-popover--equations .head .eq-popover-add:hover {
   background: rgba(255, 255, 255, 0.05);
   border-color: transparent;

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -1,0 +1,427 @@
+/*
+ * Wireframe styles for the editor's chrome. Low-fidelity, structural only.
+ * Pulls the design system tokens via the import below so the wireframe
+ * inherits the NeSyCat dark-glass feel automatically.
+ */
+
+@import url("../00-design-system/tokens.css");
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-canvas-bg);
+  color: var(--color-text-secondary);
+  font-family: var(--font-geist-sans);
+}
+
+/* ───────── Page chrome ───────── */
+
+.page-header {
+  padding: 28px 40px 8px;
+  border-bottom: 1px solid var(--color-glass-border);
+}
+.page-header p {
+  max-width: 720px;
+  color: var(--color-text-muted);
+  margin: 8px 0 0;
+}
+
+.wireframe-section {
+  padding: 24px 40px 56px;
+  border-bottom: 1px solid var(--color-glass-border);
+}
+.wireframe-section h2 {
+  margin: 0 0 4px;
+}
+.wireframe-section .lead {
+  color: var(--color-text-muted);
+  margin: 0 0 24px;
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 720px;
+}
+
+/* ───────── Editor frame (the wireframe canvas) ───────── */
+
+.editor-frame {
+  position: relative;
+  width: 100%;
+  height: 720px;
+  border: 1px dashed var(--color-glass-border);
+  border-radius: var(--size-radius-md);
+  overflow: hidden;
+  background: var(--color-canvas-bg);
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  /* Faint dot grid mimicking the React Flow background. */
+  background-image: radial-gradient(var(--canvas-grid-color) 1px, transparent 1px);
+  background-size: 12px 12px;
+}
+
+/* ───────── Left sidebar ───────── */
+
+.sidebar {
+  position: relative;
+  border-right: 1px solid var(--color-glass-border);
+  background: rgba(15, 15, 20, 0.55);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  display: flex;
+  flex-direction: column;
+  z-index: 2;
+}
+.sidebar-brand {
+  padding: 18px 16px 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--color-glass-border);
+}
+.sidebar-brand .logo-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  border: 1.3px solid var(--color-accent-blue);
+  background: rgba(var(--color-accent-rgb), 0.15);
+  position: relative;
+}
+.sidebar-brand .logo-mark::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border: 1.3px solid var(--color-accent-blue);
+  transform: rotate(45deg);
+  background: rgba(var(--color-accent-rgb), 0.22);
+}
+.sidebar-brand .name { font-weight: 600; font-size: 15px; color: var(--color-text-primary); letter-spacing: -0.3px; }
+.sidebar-search {
+  display: flex;
+  gap: 8px;
+  padding: 12px 12px 8px;
+}
+.sidebar-search input {
+  flex: 1;
+  background: var(--color-glass-button-bg);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 6px;
+  color: var(--color-text-secondary);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 7px 10px;
+  outline: none;
+}
+.sidebar-search input::placeholder { color: var(--color-text-dimmed); }
+.sidebar-search .plus {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-primary);
+  font-size: 18px;
+  cursor: pointer;
+}
+.sidebar-list {
+  flex: 1;
+  overflow: auto;
+  padding: 4px 0;
+}
+.diagram-row {
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-bottom: 1px solid var(--color-glass-border);
+  cursor: pointer;
+}
+.diagram-row.active { background: rgba(var(--color-accent-rgb), 0.10); }
+.diagram-row .title { color: var(--color-text-primary); font-size: 13px; font-weight: 500; }
+.diagram-row .meta { color: var(--color-text-dimmed); font-family: var(--font-geist-mono); font-size: 10px; }
+
+.sidebar-collapse {
+  position: absolute;
+  top: 50%;
+  right: -14px;
+  width: 22px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 4px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-panel-bg);
+  color: var(--color-text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  z-index: 3;
+}
+
+/* ───────── Canvas placeholder ───────── */
+
+.canvas-area {
+  position: relative;
+  overflow: hidden;
+}
+.canvas-placeholder {
+  position: absolute;
+  inset: 96px 80px 96px 24px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 32px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.canvas-placeholder strong { color: var(--color-text-primary); }
+
+/* ───────── Floating toolbars ───────── */
+
+.glass-bar {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--size-radius-md);
+  z-index: 4;
+}
+.glass-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 11px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.glass-btn:hover { background: var(--color-glass-button-bg); border-color: var(--color-glass-border); }
+.glass-btn.is-primary {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  border-color: rgba(var(--color-accent-rgb), 0.7);
+  color: var(--color-text-primary);
+}
+
+.toolbar-topleft {
+  top: 12px;
+  left: 12px;
+}
+.toolbar-topleft .divider {
+  width: 1px;
+  height: 18px;
+  background: var(--color-glass-border);
+  margin: 0 2px;
+}
+.toolbar-toggle {
+  display: inline-flex;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--color-glass-border);
+}
+.toolbar-toggle .glass-btn { border-radius: 0; border: none; padding: 6px 10px; }
+.toolbar-toggle .glass-btn.is-active { background: var(--color-glass-button-bg); color: var(--color-text-primary); }
+
+.json-panel-closed { top: 12px; right: 12px; }
+.json-panel-open {
+  top: 12px;
+  right: 12px;
+  width: 320px;
+  height: 280px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
+}
+.json-panel-open .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-glass-border);
+}
+.json-panel-open .header .left { display: flex; gap: 6px; align-items: center; }
+.json-panel-open .body {
+  flex: 1;
+  overflow: auto;
+  padding: 12px;
+  font-family: var(--font-geist-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  background: rgba(0, 0, 0, 0.25);
+  white-space: pre;
+  line-height: 1.5;
+}
+
+.controls-cluster {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  display: inline-flex;
+  flex-direction: column;
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--size-radius-md);
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  overflow: hidden;
+  z-index: 4;
+}
+.controls-cluster button {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-glass-border);
+  cursor: pointer;
+}
+.controls-cluster button:last-child { border-bottom: none; }
+
+/* ───────── Annotation column ───────── */
+
+.with-annotations {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 24px;
+}
+.annotations {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.annotations .note {
+  border-left: 2px solid rgba(var(--color-accent-rgb), 0.6);
+  padding: 6px 10px;
+  background: var(--color-glass-button-bg);
+  border-radius: 4px;
+}
+.annotations .note .pin {
+  display: inline-block;
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  color: var(--color-accent-blue);
+  margin-right: 6px;
+}
+.annotations h3 { color: var(--color-text-primary); font-size: 13px; margin: 12px 0 4px; }
+
+/* ───────── Open Kinds menu (separate state) ───────── */
+
+.kinds-menu {
+  position: absolute;
+  top: 56px;
+  left: 12px;
+  width: 240px;
+  padding: 6px;
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--size-radius-md);
+  z-index: 4;
+}
+.kinds-menu .row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 7px 10px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.kinds-menu .row:hover { background: var(--color-glass-button-bg); }
+.kinds-menu .row.is-toggled .name { color: var(--color-text-primary); }
+.kinds-menu .row .name { display: flex; align-items: center; gap: 8px; }
+.kinds-menu .row .hint {
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  color: var(--color-text-dimmed);
+}
+.kinds-menu .divider { height: 1px; background: var(--color-glass-border); margin: 6px 4px; }
+.kinds-menu .check {
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--color-glass-border);
+  border-radius: 3px;
+}
+.kinds-menu .check.on {
+  background: rgba(var(--color-accent-rgb), 0.5);
+  border-color: rgba(var(--color-accent-rgb), 0.8);
+}
+
+/* ───────── Star-prompt modal (alternate state) ───────── */
+
+.modal-frame {
+  position: relative;
+  width: 100%;
+  height: 360px;
+  border: 1px dashed var(--color-glass-border);
+  border-radius: var(--size-radius-md);
+  overflow: hidden;
+  background: var(--color-canvas-bg);
+}
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: grid;
+  place-items: center;
+}
+.modal-body {
+  width: 380px;
+  padding: 28px;
+  background: var(--color-canvas-bg);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 12px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: center;
+}
+.modal-body .star {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  background: rgba(var(--color-accent-rgb), 0.18);
+  border: 1px solid rgba(var(--color-accent-rgb), 0.5);
+  display: grid; place-items: center;
+  color: var(--color-accent-blue);
+  font-size: 20px;
+}
+.modal-body .btn-row {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  justify-content: center;
+}
+.modal-body .btn {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+}
+.modal-body .btn.is-primary {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  border-color: rgba(var(--color-accent-rgb), 0.7);
+  color: var(--color-text-primary);
+}

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -7,7 +7,7 @@
  * the real viewport once the macOS chrome is removed.
  *
  * Token + styling sources cited inline next to each rule:
- *   EditorSidebar.tsx           — sidebar
+ *   Top bar (shape tools + share)     — replaces left rail in this wireframe
  *   Canvas.tsx (Kinds toolbar)  — top-left
  *   Canvas.tsx (KindRow + Kbd)  — Kinds menu
  *   Canvas.tsx (JSON panel)     — top-right
@@ -64,12 +64,13 @@ body {
  *     <EditorSidebar diagrams={diagrams} />
  *   </div>
  * Width fixed at 1728, height 1080, no scrollbars. CSS var
- * `--sidebar-offset` mirrors the rail width so canvas chrome aligns with the
- * sidebar (rail is always visible in this wireframe — not collapsible).
+ * `--sidebar-offset` is 0 (top bar only; rail removed from this wireframe).
+ * `--editor-topbar-height` reserves space for the horizontal tool strip + share.
  */
 
 .editor-frame {
-  --sidebar-offset: 56px;
+  --sidebar-offset: 0px;
+  --editor-topbar-height: 52px;
   position: relative;
   width: 1728px;
   height: 1080px;
@@ -83,27 +84,110 @@ body {
 /* Canvas dot grid (mirrors React Flow <Background variant="dots" gap={20} size={1} />) */
 .editor-frame .canvas-bg {
   position: absolute;
-  inset: 0;
+  top: var(--editor-topbar-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
   background-image: radial-gradient(var(--canvas-grid-color) 1px, transparent 1px);
   background-size: 20px 20px;
   z-index: 0;
 }
 
-/* ───────── Left sidebar — Shape-spine tool rail ─────────
+/* ───────── Top bar — logo + horizontal tool strip + share ───────── */
+
+.editor-topbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--editor-topbar-height);
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 0 10px 0 6px;
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border-bottom: 1px solid var(--color-glass-border);
+  overflow: hidden;
+}
+
+/* Logo + shape tools: one row, same 6px rhythm as between rail buttons (see .topbar-tools). */
+.topbar-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.topbar-brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  text-decoration: none;
+  position: relative;
+}
+/* Full-height vertical rule centered in the 6px gap between logo and tools (matches .topbar-toolbar gap). */
+.topbar-brand::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 3px);
+  width: 1px;
+  height: var(--editor-topbar-height);
+  transform: translate(-50%, -50%);
+  background: var(--color-glass-border);
+  pointer-events: none;
+}
+.topbar-brand:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.topbar-tools {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+/* Share uses .sidebar-tool (same 40×40, radius 6, hover/focus chrome as shape tools). */
+.sidebar-tool.topbar-share.is-panel-open {
+  background: rgba(var(--color-accent-rgb), 0.18);
+  border-color: rgba(var(--color-accent-rgb), 0.5);
+  color: var(--color-text-primary);
+}
+.editor-topbar .sidebar-tool {
+  flex-shrink: 0;
+}
+
+/* ───────── Left sidebar (reference / vertical mock only — not used in frames) ─────────
  *
- * 56-wide vertical rail. The buttons mirror the user-facing slots of
- * `Shape<K>` in components/editor/types.ts (lines 116-126):
+ * 56-wide vertical rail. Buttons mirror user-facing fields of `Shape<K>`
+ * in components/editor/types.ts (lines 116-126), in declaration order:
  *
- *   slot (-1) name       → tool-name        — Geist “A” (label)
- *   slot  (0) points     → tool-points      — two dots, wider spacing
- *   slot  (1) kind       → tool-kind        — triangle (representative kind)
- *   slot  (2) order      → tool-order       — three ascending bars
- *   slot  (3) color      → tool-color       — filled disk in current shape color
- *   slot  (4) transform  → tool-transform   — 4-way move arrows (translate/rotate/scale)
- *   slot  (5) equations  → tool-equations   — "=" glyph
- *   slot  (6) weight     → tool-weight      — kettlebell glyph
+ *   name        → tool-name        — Geist “A” (label)
+ *   points      → tool-points      — two dots, wider spacing
+ *   kind        → tool-kind        — triangle (representative kind)
+ *   order       → tool-order       — three ascending bars
+ *   color       → tool-color       — filled disk in current shape color
+ *   transform   → tool-transform   — 4-way move arrows (translate/rotate/scale)
+ *   equations   → tool-equations   — "=" glyph
+ *   weight      → tool-weight      — kettlebell glyph
  *
- * `id` (slot -2) is internal-only (types.ts:29) and has no button.
+ * Internal-only `id` (types.ts:29) has no button.
  * File-management (search / +new / diagram list) moves out of the sidebar;
  * picker lives elsewhere in a later iteration.
  */
@@ -143,7 +227,7 @@ body {
 /* Inline SVG logo mark (matches LogoMark in EditorSidebar.tsx). */
 .logo-mark { width: 22px; height: 22px; flex-shrink: 0; }
 
-/* Tool list — vertically stacked icon buttons, one per Shape slot. */
+/* Tool list — vertically stacked icon buttons, one per editable Shape field. */
 .sidebar-tools {
   display: flex;
   flex-direction: column;
@@ -209,7 +293,10 @@ body {
 
 .canvas-area {
   position: absolute;
-  inset: 0;
+  top: var(--editor-topbar-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 1;
 }
 
@@ -223,8 +310,8 @@ body {
 
 .toolbar-topleft {
   position: absolute;
-  top: 12px;
-  left: calc(12px + var(--sidebar-offset));
+  top: calc(12px + var(--editor-topbar-height));
+  left: 12px;
   z-index: 10;
   display: flex;
   gap: 8px;
@@ -266,8 +353,8 @@ body {
   padding: 6px 6px;
   min-width: 220px;
 }
-/* KindRow — Canvas.tsx 730-755 */
-.kind-row {
+/* KindRow — Canvas.tsx 730-755 (scoped: only the mock “Kinds” dropdown, not the Kind popover list) */
+.kinds-menu .kind-row {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -279,9 +366,9 @@ body {
   cursor: pointer;
   user-select: none;
 }
-.kind-row.is-on  { color: var(--color-text-secondary); }
-.kind-row:hover  { background: rgba(255, 255, 255, 0.04); }
-.kind-row .dot {
+.kinds-menu .kind-row.is-on  { color: var(--color-text-secondary); }
+.kinds-menu .kind-row:hover  { background: rgba(255, 255, 255, 0.04); }
+.kinds-menu .kind-row .dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
@@ -290,13 +377,13 @@ body {
   margin-left: 2px;
   flex-shrink: 0;
 }
-.kind-row.is-on .dot {
+.kinds-menu .kind-row.is-on .dot {
   background: rgba(var(--color-accent-rgb), 0.9);
   border-color: transparent;
   box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
 }
-.kind-row .label { flex: 1; }
-.kind-row .kbds {
+.kinds-menu .kind-row .label { flex: 1; }
+.kinds-menu .kind-row .kbds {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
@@ -324,9 +411,10 @@ body {
 
 /* ───────── Top-right JSON button + panel (Canvas.tsx 671-710) ───────── */
 
-.topright {
+.topright,
+.json-panel-anchor {
   position: absolute;
-  top: 12px;
+  top: calc(12px + var(--editor-topbar-height));
   right: 12px;
   z-index: 10;
   display: flex;
@@ -399,7 +487,7 @@ body {
 .controls-cluster {
   position: absolute;
   bottom: 12px;
-  left: calc(12px + var(--sidebar-offset));
+  left: 12px;
   z-index: 10;
   background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
@@ -537,14 +625,15 @@ code {
  *
  * One popover per rail button. Floats just to the right of the 56-wide rail
  * at the y-position of the originating button. Anchored to `.editor-frame`.
- * Structure: header (caption) → body (editor) → vis-footer (3-state
- * "Off · Selected · All"). The visibility footer is parked at the bottom
- * per the user's choice — editor stays in the visual foreground.
+ * Structure: header row (caption + KindRow-style visibility dot) → body (editor).
+ * Dot matches `KindRow` in Canvas.tsx (630–743) / `.kind-row .dot` in this stylesheet.
+ * Visibility lives in `.head` — same glass panel as the body (no separate footer band).
  */
 
 .tool-popover {
   position: absolute;
-  left: calc(var(--sidebar-offset) + 8px);
+  left: 8px;
+  top: 8px;
   z-index: 12;
   min-width: 240px;
   background: var(--color-glass-panel-bg);
@@ -556,18 +645,29 @@ code {
   flex-direction: column;
   overflow: hidden;
 }
+
 .tool-popover .head {
   padding: 8px 12px;
   border-bottom: 1px solid var(--color-glass-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 36px;
+}
+.tool-popover .head-title {
   font-family: var(--font-geist-mono);
   font-size: 11px;
   font-weight: 600;
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  flex: 1;
+  min-width: 0;
 }
 .tool-popover .body {
-  padding: 12px;
+  --popover-body-pad: 12px;
+  padding: var(--popover-body-pad);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -581,50 +681,56 @@ code {
   color: var(--color-text-dimmed);
   line-height: 1.4;
 }
-.tool-popover .vis-footer {
-  padding: 10px 12px 12px;
-  border-top: 1px solid var(--color-glass-border);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  background: rgba(255, 255, 255, 0.02);
-}
-.tool-popover .vis-footer .footer-label {
-  font-family: var(--font-geist-mono);
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--color-text-dimmed);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
 
-/* 3-state visibility segmented control */
-.vis-seg {
-  display: flex;
-  gap: 4px;
-  background: var(--color-glass-button-bg);
-  border: 1px solid var(--color-glass-border);
-  border-radius: 6px;
-  padding: 2px;
-}
-.vis-seg .seg {
-  flex: 1;
-  padding: 6px 10px;
-  border: 1px solid transparent;
+/* Dot toggle — Kinds menu (Canvas.tsx KindRow); head is interactive, kind-row dots are decorative wireframe */
+.tool-popover .head .head-vis-toggle,
+.tool-popover .kind-row-left .kind-vis-toggle {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  margin: 0;
+  border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--color-text-muted);
-  font-family: var(--font-geist-sans);
-  font-size: 11px;
-  font-weight: 500;
-  cursor: pointer;
-  text-align: center;
+  flex-shrink: 0;
+  transition: background 0.12s;
 }
-.vis-seg .seg:hover  { color: var(--color-text-secondary); }
-.vis-seg .seg.is-on {
-  background: rgba(var(--color-accent-rgb), 0.22);
-  border-color: rgba(var(--color-accent-rgb), 0.5);
-  color: var(--color-text-primary);
+.tool-popover .head .head-vis-toggle {
+  cursor: pointer;
+}
+.tool-popover .kind-row-left .kind-vis-toggle {
+  cursor: default;
+}
+.tool-popover .head .head-vis-toggle:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.tool-popover .head .head-vis-dot,
+.tool-popover .kind-row-left .kind-vis-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: transparent;
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+}
+.tool-popover .head .head-vis-toggle.is-on .head-vis-dot,
+.tool-popover .kind-row-left .kind-vis-toggle.is-on .kind-vis-dot {
+  background: rgba(var(--color-accent-rgb), 0.9);
+  border-color: transparent;
+  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
+}
+
+/* Popover with no body (or header-only): width follows title + visibility control —
+   avoids the default 240px floor and flex:1 title stretching the head sideways. */
+.tool-popover.tool-popover--tight {
+  width: max-content;
+  min-width: 0;
+}
+.tool-popover.tool-popover--tight .head-title {
+  flex: 0 0 auto;
 }
 
 /* Shared form controls inside the popover body */
@@ -654,30 +760,74 @@ code {
   outline: none;
 }
 
-/* Scene 7 — kind picker (5 shape tiles) */
-.kind-picker {
+/* Scene 8 Order — numeric field to the left of horizontal slider */
+.tool-popover .order-value-row {
   display: flex;
-  gap: 8px;
-  padding-bottom: 18px;          /* room for the tile-label below */
+  align-items: center;
+  gap: 12px;
+  width: 100%;
 }
-.kind-picker .tile {
+.tool-popover .order-value-row .num-input {
+  flex: 0 0 auto;
+}
+.tool-popover .order-value-row .slider-col.slider-col--horizontal {
+  flex: 1;
+  min-width: 0;
+  width: auto;
+}
+
+/* Scene 7 — kind rows: one row per ShapeKind.
+   Bleed past body padding so each row is as wide as the glass panel; inner pad matches body. */
+.kind-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: calc(100% + 2 * var(--popover-body-pad));
+  margin-left: calc(-1 * var(--popover-body-pad));
+  margin-right: calc(-1 * var(--popover-body-pad));
+  box-sizing: border-box;
+}
+.kind-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding-left: var(--popover-body-pad);
+  padding-right: var(--popover-body-pad);
+  /* Row is chrome only: not a hit target — only .drag-tile is interactive. */
+  cursor: default;
+  pointer-events: none;
+}
+.kind-row .drag-tile {
+  pointer-events: auto;
   width: 40px;
-  height: 40px;
+  min-height: 40px;
+  flex: 0 0 auto;
   display: grid;
   place-items: center;
   border-radius: 6px;
   border: 1px solid var(--color-glass-border);
-  background: var(--color-glass-button-bg);
+  background: transparent;
   color: var(--color-text-muted);
-  cursor: pointer;
-  position: relative;
+  cursor: grab;
 }
-.kind-picker .tile.is-on {
-  background: rgba(var(--color-accent-rgb), 0.22);
-  border-color: rgba(var(--color-accent-rgb), 0.5);
+/* Left column = same 28px track as .head .head-vis-toggle so dots align vertically */
+.kind-row-left {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  flex: 0 0 28px;
+  width: 28px;
+  min-width: 28px;
+}
+.kind-row.is-active .drag-tile {
+  background: rgba(var(--color-accent-rgb), 0.14);
+  border-color: rgba(var(--color-accent-rgb), 0.45);
   color: var(--color-text-primary);
 }
-.kind-picker .tile svg {
+.kind-row .drag-tile svg {
   width: 22px;
   height: 22px;
   fill: none;
@@ -685,22 +835,55 @@ code {
   stroke-width: 1.4;
   stroke-linejoin: round;
 }
-.kind-picker .tile .tile-label {
-  position: absolute;
-  bottom: -16px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: var(--font-geist-mono);
-  font-size: 9px;
-  color: var(--color-text-dimmed);
-  white-space: nowrap;
-}
 
-/* Scenes 8 + 12 — vertical slider (Fresco "Tamaño 6,0" style) */
+/* Scene 8 — horizontal tick bar; Scene 12 — vertical (Fresco "Tamaño" style) */
 .slider-col {
   display: flex;
   align-items: flex-start;
   gap: 18px;
+}
+/* Scene 8 Order popover — track + ticks read left → right (0 … 5) */
+.slider-col.slider-col--horizontal {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  width: 100%;
+}
+.slider-col.slider-col--horizontal .slider-stack {
+  width: 100%;
+}
+.slider-col.slider-col--horizontal .slider-track {
+  width: 100%;
+  height: 4px;
+  min-height: 4px;
+}
+.slider-col.slider-col--horizontal .slider-thumb {
+  left: 40%;
+  top: 50%;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background: transparent;
+  border: none;
+  box-sizing: border-box;
+  /* Match .head-vis-toggle hit area; inner dot matches .head-vis-dot.is-on */
+}
+.slider-col.slider-col--horizontal .slider-thumb-dot {
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(var(--color-accent-rgb), 0.9);
+  border: 1px solid transparent;
+  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
+}
+.slider-col.slider-col--horizontal .slider-notches {
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  height: auto;
 }
 .slider-col .slider-stack {
   display: flex;

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -69,7 +69,17 @@ body {
  */
 
 .editor-frame {
+  /*
+   * Shape-tool geometry (used to anchor `.tool-popover`s).
+   *   stride       = button width (40) + gap (6) = 46
+   *   cluster-start = (frame 1728 − cluster 362) / 2 = 683
+   *   where cluster = 8 buttons × 40 + 7 gaps × 6 = 362
+   * Each popover declares `style="--tool-index: <0..7>"` instead of a
+   * hand-computed pixel `left`; the rule below picks up the value.
+   */
   --editor-topbar-height: 52px;
+  --shape-cluster-start: 683px;
+  --shape-tool-stride:   46px;
   position: relative;
   width: 1728px;
   height: 1080px;
@@ -429,15 +439,17 @@ code {
 /* ───────── Tool popovers — shape inspector + diagram-data panel ─────────
  *
  * Same `.tool-popover` shell everywhere: `.head` (caption row) + `.body` (editor).
- * Shape tools: anchored left via inline `style="left: …"` from `.canvas-area`.
- * Diagram data (share open): same class, `style="top: 8px; right: 12px; left: auto; width: 400px; max-height: 500px"`.
- * Head may pair `.head-title` with `.head-vis-toggle` or `.head .actions` (Export / Import).
+ * Shape-tool popovers: declare `style="--tool-index: <0..7>"`; `left` resolves
+ *   to `cluster-start + index × stride` via the .editor-frame vars above.
+ * Diagram data (share open): override `left` inline → `right: 12px; left: auto`.
+ * Head may pair `.head-title` with `.head-vis-toggle` or `.head .actions`
+ *   (Export / Import).
  */
 
 .tool-popover {
   position: absolute;
-  left: 8px;
   top: 8px;
+  left: calc(var(--shape-cluster-start) + var(--tool-index, 0) * var(--shape-tool-stride));
   z-index: 12;
   min-width: 240px;
   background: var(--color-glass-panel-bg);
@@ -521,9 +533,13 @@ code {
   line-height: 1.4;
 }
 
-/* Dot toggle — header + kind strip share .head-vis-toggle / .head-vis-dot */
-.tool-popover .head .head-vis-toggle,
-.tool-popover .kind-row-left .head-vis-toggle {
+/*
+ * Visibility dot toggle (`.head-vis-toggle` + `.head-vis-dot`). Used in
+ * popover heads and in Scene 7's per-kind column. The compact size
+ * (24×24 hit target, 5 px dot, 2 px halo) goes on popover heads via
+ * `.is-compact`; the base 28×28 / 6 px / 3 px halo stays on kind columns.
+ */
+.head-vis-toggle {
   display: grid;
   place-items: center;
   width: 28px;
@@ -533,19 +549,12 @@ code {
   border: none;
   border-radius: 4px;
   background: transparent;
+  cursor: pointer;
   flex-shrink: 0;
   transition: background 0.12s;
 }
-.tool-popover .head .head-vis-toggle,
-.tool-popover .kind-row-left .head-vis-toggle {
-  cursor: pointer;
-}
-.tool-popover .head .head-vis-toggle:hover,
-.tool-popover .kind-row-left .head-vis-toggle:hover {
-  background: rgba(255, 255, 255, 0.04);
-}
-.tool-popover .head .head-vis-dot,
-.tool-popover .kind-row-left .head-vis-dot {
+.head-vis-toggle:hover { background: rgba(255, 255, 255, 0.04); }
+.head-vis-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
@@ -554,22 +563,14 @@ code {
   flex-shrink: 0;
   transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
 }
-.tool-popover .head .head-vis-toggle.is-on .head-vis-dot,
-.tool-popover .kind-row-left .head-vis-toggle.is-on .head-vis-dot {
+.head-vis-toggle.is-on .head-vis-dot {
   background: rgba(var(--color-accent-rgb), 0.9);
   border-color: transparent;
   box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
 }
-/* Slightly tighter hit target in popover chrome only — kind columns keep 28×28 for grid rhythm. */
-.tool-popover .head .head-vis-toggle {
-  width: 24px;
-  height: 24px;
-}
-.tool-popover .head .head-vis-dot {
-  width: 5px;
-  height: 5px;
-}
-.tool-popover .head .head-vis-toggle.is-on .head-vis-dot {
+.head-vis-toggle.is-compact { width: 24px; height: 24px; }
+.head-vis-toggle.is-compact .head-vis-dot { width: 5px; height: 5px; }
+.head-vis-toggle.is-compact.is-on .head-vis-dot {
   box-shadow: 0 0 0 2px rgba(var(--color-accent-rgb), 0.2);
 }
 
@@ -1036,14 +1037,14 @@ code {
   background: linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
 }
 .color-sliders .slider-row .h-track.sat {
-  background: linear-gradient(to right, rgba(255,255,255,0.1), rgb(59,130,246));
+  background: linear-gradient(to right, rgba(255,255,255,0.1), rgb(var(--color-accent-rgb)));
 }
 .color-sliders .slider-row .h-track.val {
-  background: linear-gradient(to right, #000, rgb(59,130,246));
+  background: linear-gradient(to right, #000, rgb(var(--color-accent-rgb)));
 }
 .color-sliders .slider-row .h-track.alpha {
   background:
-    linear-gradient(to right, rgba(59,130,246,0), rgb(59,130,246)),
+    linear-gradient(to right, rgba(59,130,246,0), rgb(var(--color-accent-rgb))),
     repeating-conic-gradient(rgba(255,255,255,0.2) 0% 25%, transparent 0% 50%) 0 0 / 8px 8px;
 }
 .color-sliders .slider-row .h-thumb {

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -172,6 +172,22 @@ body {
 .editor-topbar .sidebar-tool {
   flex-shrink: 0;
 }
+/* Match .topbar-brand:hover — subtle fill, no glass border ring (sidebar rail keeps glass hover). */
+.editor-topbar .sidebar-tool:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: transparent;
+  color: var(--color-text-muted);
+}
+.editor-topbar .sidebar-tool.is-active:hover {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  border-color: rgba(var(--color-accent-rgb), 0.55);
+  color: var(--color-text-primary);
+}
+.editor-topbar .sidebar-tool.topbar-share.is-panel-open:hover {
+  background: rgba(var(--color-accent-rgb), 0.25);
+  border-color: rgba(var(--color-accent-rgb), 0.55);
+  color: var(--color-text-primary);
+}
 
 /* ───────── Left sidebar (reference / vertical mock only — not used in frames) ─────────
  *

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -69,7 +69,7 @@ body {
  */
 
 .editor-frame {
-  --sidebar-offset: 240px;
+  --sidebar-offset: 56px;
   position: relative;
   width: 1728px;
   height: 1080px;
@@ -95,11 +95,23 @@ body {
   z-index: 0;
 }
 
-/* ───────── Left sidebar (EditorSidebar.tsx) ───────── */
-/*
- * width 240, glass-panel-bg, 3px backdrop blur, border-right glass-border.
- * Brand row: 14px vert padding, 16px horiz, 10px gap, border-bottom.
- * Brand text: 15px, 600wt, primary, -0.3px letter-spacing.
+/* ───────── Left sidebar — Shape-spine tool rail ─────────
+ *
+ * 56-wide vertical rail. The buttons mirror the user-facing slots of
+ * `Shape<K>` in components/editor/types.ts (lines 116-126):
+ *
+ *   slot (-1) name       → tool-name        — pencil glyph
+ *   slot  (0) points     → tool-points      — two dots
+ *   slot  (1) kind       → tool-kind        — triangle (representative kind)
+ *   slot  (2) order      → tool-order       — three ascending bars
+ *   slot  (3) color      → tool-color       — filled disk in current shape color
+ *   slot  (4) transform  → tool-transform   — 4-way move arrows (translate/rotate/scale)
+ *   slot  (5) equations  → tool-equations   — "=" glyph
+ *   slot  (6) weight     → tool-weight      — kettlebell glyph
+ *
+ * `id` (slot -2) is internal-only (types.ts:29) and has no button.
+ * File-management (search / +new / diagram list) moves out of the sidebar;
+ * picker lives elsewhere in a later iteration.
  */
 
 .sidebar {
@@ -107,7 +119,7 @@ body {
   top: 0;
   left: 0;
   bottom: 0;
-  width: 240px;
+  width: 56px;
   background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
   -webkit-backdrop-filter: blur(var(--effect-blur));
@@ -118,92 +130,81 @@ body {
   overflow: hidden;
   transition: width 200ms;
 }
-/* Inner content keeps its 240 width even when the outer collapses so the
+/* Inner content keeps its 56 width even when the outer collapses so the
    collapse looks like a slide rather than a reflow (matches the live app). */
 .sidebar > .sidebar-inner {
-  width: 240px;
+  width: 56px;
   height: 100%;
   display: flex;
   flex-direction: column;
 }
 
+/* Logo at top — icon only, no brand text. */
 .sidebar-brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 16px;
+  display: grid;
+  place-items: center;
+  padding: 14px 0;
   border-bottom: 1px solid var(--color-glass-border);
   text-decoration: none;
 }
 .sidebar-brand:hover { background: rgba(255, 255, 255, 0.05); }
-.sidebar-brand .brand-name {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  letter-spacing: -0.3px;
-  white-space: nowrap;
-}
 
 /* Inline SVG logo mark (matches LogoMark in EditorSidebar.tsx). */
 .logo-mark { width: 22px; height: 22px; flex-shrink: 0; }
 
-.sidebar-search-row {
+/* Tool list — vertically stacked icon buttons, one per Shape slot. */
+.sidebar-tools {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 12px 12px 0;
+  gap: 6px;
+  padding: 10px 0;
 }
-.sidebar-search {
-  position: relative;
-  flex: 1;
-  min-width: 0;
-}
-.sidebar-search input {
-  width: 100%;
-  height: 36px;
-  padding: 0 12px;
-  border-radius: 6px;
-  border: 1px solid var(--color-glass-border);
-  background: var(--color-glass-button-bg);
-  color: var(--color-text-primary);
-  font-size: 13px;
-  font-family: inherit;
-  outline: none;
-}
-.sidebar-search input::placeholder { color: var(--color-text-dimmed); }
-.sidebar-new {
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
+.sidebar-tool {
+  width: 40px;
+  height: 40px;
   display: grid;
   place-items: center;
   border-radius: 6px;
-  border: 1px solid var(--color-glass-border);
-  background: var(--color-glass-button-bg);
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--color-text-muted);
-  font-family: var(--font-geist-sans);
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 1;
   cursor: pointer;
+  padding: 0;
+  position: relative;
 }
-
-.sidebar-list {
-  flex: 1;
-  overflow: auto;
-  padding-top: 12px;
+.sidebar-tool:hover {
+  background: var(--color-glass-button-bg);
+  border-color: var(--color-glass-border);
+  color: var(--color-text-secondary);
 }
-.diagram-row {
-  padding: 10px 16px;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.sidebar-tool.is-active {
+  background: rgba(var(--color-accent-rgb), 0.18);
+  border-color: rgba(var(--color-accent-rgb), 0.5);
+  color: var(--color-text-primary);
 }
-.diagram-row:hover { background: rgba(255, 255, 255, 0.04); }
-.diagram-row.active { background: rgba(var(--color-accent-rgb), 0.10); }
-.diagram-row .title { color: var(--color-text-primary); font-size: 13px; font-weight: 500; line-height: 1.3; }
-.diagram-row .meta { color: var(--color-text-dimmed); font-size: 11px; line-height: 1.3; }
+.sidebar-tool svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+/* `tool-color`'s glyph IS the color — render it as a filled disk in the
+   shape's current color (default accent), no stroke. */
+.sidebar-tool.tool-color svg {
+  fill: var(--color-accent-blue);
+  stroke: rgba(255, 255, 255, 0.45);
+  stroke-width: 1;
+}
+/* `tool-points` and `tool-equations` glyphs read better as filled shapes. */
+.sidebar-tool.tool-points svg,
+.sidebar-tool.tool-equations svg {
+  fill: currentColor;
+  stroke: none;
+}
 
 /* Collapse handle — sits at the right edge of the sidebar (or at the left
    edge of the canvas when collapsed). Positioned on `.editor-frame` rather
@@ -212,7 +213,7 @@ body {
 .sidebar-handle {
   position: absolute;
   top: 50%;
-  left: var(--sidebar-offset, 240px);
+  left: var(--sidebar-offset, 56px);
   transform: translateY(-50%);
   width: 28px;
   height: 64px;

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -10,7 +10,7 @@
  *   Top bar (shape tools + share)     — replaces left rail in this wireframe
  *   Canvas.tsx (Kinds toolbar)  — top-left
  *   Canvas.tsx (KindRow + Kbd)  — Kinds menu
- *   Canvas.tsx (JSON panel)     — top-right
+ *   Canvas.tsx (diagram data panel) — reuse `.tool-popover`
  *   ReactFlow <Controls/>       — bottom-left zoom cluster
  *   ../00-design-system/tokens.css — colours + typography
  */
@@ -104,7 +104,7 @@ body {
   z-index: 5;
   display: flex;
   align-items: center;
-  gap: 0;
+  justify-content: space-between;
   padding: 0 10px 0 6px;
   background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
@@ -113,13 +113,23 @@ body {
   overflow: hidden;
 }
 
-/* Logo + shape tools: one row, same 6px rhythm as between rail buttons (see .topbar-tools). */
-.topbar-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex: 1 1 auto;
-  min-width: 0;
+/* Left chrome (logo). Rail tools are centered on the full bar via .topbar-center (absolute). */
+.topbar-leading {
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 1;
+  padding-right: 6px;
+}
+.topbar-leading::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 1px;
+  height: var(--editor-topbar-height);
+  transform: translateY(-50%);
+  background: var(--color-glass-border);
+  pointer-events: none;
 }
 .topbar-brand {
   display: flex;
@@ -131,29 +141,32 @@ body {
   box-sizing: border-box;
   border-radius: 8px;
   text-decoration: none;
-  position: relative;
-}
-/* Full-height vertical rule centered in the 6px gap between logo and tools (matches .topbar-toolbar gap). */
-.topbar-brand::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: calc(100% + 3px);
-  width: 1px;
-  height: var(--editor-topbar-height);
-  transform: translate(-50%, -50%);
-  background: var(--color-glass-border);
-  pointer-events: none;
 }
 .topbar-brand:hover {
   background: rgba(255, 255, 255, 0.05);
+}
+/* Tool cluster: geometric center of the bar — not in flex flow so logo + share stay at edges. */
+.topbar-center {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 0;
+  pointer-events: none;
+}
+.topbar-center .topbar-tools {
+  pointer-events: auto;
 }
 .topbar-tools {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 6px;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-width: 0;
 }
 .topbar-actions {
@@ -161,7 +174,7 @@ body {
   align-items: center;
   gap: 6px;
   flex: 0 0 auto;
-  margin-left: auto;
+  z-index: 1;
 }
 /* Share uses .sidebar-tool (same 40×40, radius 6, hover/focus chrome as shape tools). */
 .sidebar-tool.topbar-share.is-panel-open {
@@ -425,10 +438,9 @@ body {
   white-space: nowrap;
 }
 
-/* ───────── Top-right JSON button + panel (Canvas.tsx 671-710) ───────── */
+/* ───────── `.topright` — anchor hook for future chrome (unused in current wireframe HTML). ───────── */
 
-.topright,
-.json-panel-anchor {
+.topright {
   position: absolute;
   top: calc(12px + var(--editor-topbar-height));
   right: 12px;
@@ -437,62 +449,6 @@ body {
   flex-direction: column;
   gap: 8px;
   align-items: flex-end;
-}
-
-.json-panel {
-  width: 400px;
-  max-height: 500px;
-  background: var(--color-glass-panel-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  border: 1px solid var(--color-glass-border);
-  border-radius: 8px;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.json-panel .header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--color-glass-border);
-}
-.json-panel .header .label {
-  font-family: var(--font-geist-mono);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-.json-panel .header .actions {
-  display: flex;
-  gap: 6px;
-}
-.json-panel .header .actions button {
-  background: var(--color-glass-button-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  border: 1px solid var(--color-glass-border);
-  border-radius: 4px;
-  color: var(--color-text-secondary);
-  font-family: var(--font-geist-sans);
-  font-size: 11px;
-  padding: 2px 10px;
-  cursor: pointer;
-}
-.json-panel .body {
-  flex: 1;
-  margin: 0;
-  padding: 12px;
-  background: rgba(0, 0, 0, 0.25);
-  color: var(--color-text-muted);
-  font-family: var(--font-geist-mono);
-  font-size: 10px;
-  line-height: 1.4;
-  white-space: pre;
-  overflow: auto;
 }
 
 /* ───────── Bottom-left zoom controls (React Flow <Controls />) ─────────
@@ -637,13 +593,12 @@ code {
   font-size: 0.92em;
 }
 
-/* ───────── Tool popovers (rail button → editor panel) ─────────
+/* ───────── Tool popovers — shape inspector + diagram-data panel ─────────
  *
- * One popover per rail button. Floats just to the right of the 56-wide rail
- * at the y-position of the originating button. Anchored to `.editor-frame`.
- * Structure: header row (caption + KindRow-style visibility dot) → body (editor).
- * Dot matches `KindRow` in Canvas.tsx (630–743) / `.kind-row .dot` in this stylesheet.
- * Visibility lives in `.head` — same glass panel as the body (no separate footer band).
+ * Same `.tool-popover` shell everywhere: `.head` (caption row) + `.body` (editor).
+ * Shape tools: anchored left via inline `style="left: …"` from `.canvas-area`.
+ * Diagram data (share open): same class, `style="top: 8px; right: 12px; left: auto; width: 400px; max-height: 500px"`.
+ * Head may pair `.head-title` with `.head-vis-toggle` or `.head .actions` (Export / Import).
  */
 
 .tool-popover {
@@ -663,13 +618,13 @@ code {
 }
 
 .tool-popover .head {
-  padding: 8px 12px;
+  padding: 5px 12px;
   border-bottom: 1px solid var(--color-glass-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  min-height: 36px;
+  gap: 8px;
+  min-height: 30px;
 }
 .tool-popover .head-title {
   font-family: var(--font-geist-mono);
@@ -681,12 +636,47 @@ code {
   flex: 1;
   min-width: 0;
 }
+/* Diagram-data strip — same `.head` chrome as visibility-dot popovers (Export / Import only). */
+.tool-popover .head .actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.tool-popover .head .actions button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--color-text-muted);
+  font-family: var(--font-geist-sans);
+  font-size: 11px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.tool-popover .head .actions button:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: transparent;
+  color: var(--color-text-muted);
+}
+
 .tool-popover .body {
   --popover-body-pad: 12px;
   padding: var(--popover-body-pad);
   display: flex;
   flex-direction: column;
   gap: 10px;
+  flex: 1;
+  min-height: 0;
+}
+.tool-popover .body > pre {
+  margin: 0;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--color-text-muted);
+  white-space: pre;
 }
 .tool-popover .body .body-label {
   font-size: 11px;
@@ -698,9 +688,9 @@ code {
   line-height: 1.4;
 }
 
-/* Dot toggle — Kinds menu (Canvas.tsx KindRow); head is interactive, kind-row dots are decorative wireframe */
+/* Dot toggle — header + kind strip share .head-vis-toggle / .head-vis-dot */
 .tool-popover .head .head-vis-toggle,
-.tool-popover .kind-row-left .kind-vis-toggle {
+.tool-popover .kind-row-left .head-vis-toggle {
   display: grid;
   place-items: center;
   width: 28px;
@@ -713,17 +703,16 @@ code {
   flex-shrink: 0;
   transition: background 0.12s;
 }
-.tool-popover .head .head-vis-toggle {
+.tool-popover .head .head-vis-toggle,
+.tool-popover .kind-row-left .head-vis-toggle {
   cursor: pointer;
 }
-.tool-popover .kind-row-left .kind-vis-toggle {
-  cursor: default;
-}
-.tool-popover .head .head-vis-toggle:hover {
+.tool-popover .head .head-vis-toggle:hover,
+.tool-popover .kind-row-left .head-vis-toggle:hover {
   background: rgba(255, 255, 255, 0.04);
 }
 .tool-popover .head .head-vis-dot,
-.tool-popover .kind-row-left .kind-vis-dot {
+.tool-popover .kind-row-left .head-vis-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
@@ -733,10 +722,22 @@ code {
   transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
 }
 .tool-popover .head .head-vis-toggle.is-on .head-vis-dot,
-.tool-popover .kind-row-left .kind-vis-toggle.is-on .kind-vis-dot {
+.tool-popover .kind-row-left .head-vis-toggle.is-on .head-vis-dot {
   background: rgba(var(--color-accent-rgb), 0.9);
   border-color: transparent;
   box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
+}
+/* Slightly tighter hit target in popover chrome only — kind columns keep 28×28 for grid rhythm. */
+.tool-popover .head .head-vis-toggle {
+  width: 24px;
+  height: 24px;
+}
+.tool-popover .head .head-vis-dot {
+  width: 5px;
+  height: 5px;
+}
+.tool-popover .head .head-vis-toggle.is-on .head-vis-dot {
+  box-shadow: 0 0 0 2px rgba(var(--color-accent-rgb), 0.2);
 }
 
 /* Popover with no body (or header-only): width follows title + visibility control —
@@ -792,31 +793,36 @@ code {
   width: auto;
 }
 
-/* Scene 7 — kind rows: one row per ShapeKind.
-   Bleed past body padding so each row is as wide as the glass panel; inner pad matches body. */
-.kind-rows {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  width: calc(100% + 2 * var(--popover-body-pad));
-  margin-left: calc(-1 * var(--popover-body-pad));
-  margin-right: calc(-1 * var(--popover-body-pad));
-  box-sizing: border-box;
+/* Scene 7 — kind strip on .body (merged: no inner .kind-rows wrapper). */
+.tool-popover .body.kind-rows {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 8px;
+  flex-wrap: nowrap;
+  padding-top: 6px;
+  padding-right: var(--popover-body-pad);
+  padding-bottom: var(--popover-body-pad);
+  padding-left: var(--popover-body-pad);
 }
 .kind-row {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  width: 100%;
+  gap: 6px;
+  width: auto;
+  flex: 0 0 auto;
   box-sizing: border-box;
-  padding-left: var(--popover-body-pad);
-  padding-right: var(--popover-body-pad);
-  /* Row is chrome only: not a hit target — only .drag-tile is interactive. */
+  padding-left: 0;
+  padding-right: 0;
+  /* Column chrome: row ignores hits; drag tiles + visibility toggles receive clicks. */
   cursor: default;
   pointer-events: none;
 }
-.kind-row .drag-tile {
+.kind-row .drag-tile,
+.kind-row .head-vis-toggle {
   pointer-events: auto;
+}
+.kind-row .drag-tile {
   width: 40px;
   min-height: 40px;
   flex: 0 0 auto;
@@ -828,15 +834,15 @@ code {
   color: var(--color-text-muted);
   cursor: grab;
 }
-/* Left column = same 28px track as .head .head-vis-toggle so dots align vertically */
+/* Dot above tile — centered in each kind column */
 .kind-row-left {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  flex: 0 0 28px;
-  width: 28px;
-  min-width: 28px;
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 0;
 }
 .kind-row.is-active .drag-tile {
   background: rgba(var(--color-accent-rgb), 0.14);
@@ -888,8 +894,8 @@ code {
 }
 .slider-col.slider-col--horizontal .slider-thumb-dot {
   display: block;
-  width: 6px;
-  height: 6px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   background: rgba(var(--color-accent-rgb), 0.9);
   border: 1px solid transparent;
@@ -950,22 +956,225 @@ code {
   border: 1px solid rgba(var(--color-accent-rgb), 0.7);
 }
 
-/* Scene 9 — color picker */
+/* Scene 12 — weight: numeric field above vertical track (preview column on the right) */
+.tool-popover .weight-slider-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+.tool-popover .weight-num-row {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+.tool-popover .slider-col--weight {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 18px;
+  width: 100%;
+}
+/* Frame fills the grid cell; inner disk fixed size; ::before = maximal inscribed circle (max weight symbol) */
+.tool-popover .slider-col--weight > .preview-col.preview-col--weight-square {
+  position: relative;
+  container-type: size;
+  margin-top: 0;
+  flex: none;
+  box-sizing: border-box;
+  justify-self: stretch;
+  align-self: stretch;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.tool-popover .slider-col--weight > .preview-col.preview-col--weight-square::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  translate: -50% -50%;
+  width: 100cqmin;
+  height: 100cqmin;
+  box-sizing: border-box;
+  border-radius: 50%;
+  border: 1px solid var(--color-glass-border);
+  pointer-events: none;
+  z-index: 0;
+}
+.tool-popover .slider-col--weight > .preview-col.preview-col--weight-square .preview-disk {
+  position: relative;
+  z-index: 1;
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+/* Weight thumb — accent dot + halo (scaled up from header visibility dot for grab affordance) */
+.tool-popover .weight-slider-controls .slider-thumb {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(var(--color-accent-rgb), 0.9);
+  border: 1px solid transparent;
+  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
+  box-sizing: border-box;
+}
+
+/* Scene 9 — color picker (Fresco-like: spectral hue ring, S/V field, corner presets, opacity under wheel) */
+.tool-popover--color .body {
+  gap: 12px;
+}
 .color-wheel {
   width: 220px;
   height: 220px;
   position: relative;
   margin: 0 auto;
 }
-.color-current {
+.color-wheel-frame {
   position: absolute;
-  top: 6px;
-  left: 6px;
-  width: 22px;
-  height: 22px;
+  inset: 0;
   border-radius: 50%;
-  background: var(--color-accent-blue);
-  border: 2px solid rgba(255, 255, 255, 0.6);
+}
+/* Full-spectrum ring — annulus: thin band; hole large enough that S/V square sits fully inside with gap */
+.color-hue-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  z-index: 1;
+  background: conic-gradient(
+    from 0deg,
+    hsl(0, 100%, 50%),
+    hsl(60, 100%, 50%),
+    hsl(120, 100%, 50%),
+    hsl(180, 100%, 50%),
+    hsl(240, 100%, 50%),
+    hsl(300, 100%, 50%),
+    hsl(360, 100%, 50%)
+  );
+  /* Hole ~75px radius → square ≤105px inscribed; ring 75→87 (~12px thick); fade ~88px */
+  -webkit-mask: radial-gradient(
+    circle at 50% 50%,
+    transparent 0,
+    transparent 74px,
+    #000 75px,
+    #000 87px,
+    transparent 88px
+  );
+  mask: radial-gradient(
+    circle at 50% 50%,
+    transparent 0,
+    transparent 74px,
+    #000 75px,
+    #000 87px,
+    transparent 88px
+  );
+  pointer-events: none;
+  filter: saturate(1.15) brightness(1.06);
+}
+.color-hue-thumb {
+  position: absolute;
+  z-index: 4;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  margin-top: -7px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
+  left: calc(50% + 81px);
+  top: 50%;
+  pointer-events: none;
+}
+.color-sv-field {
+  position: absolute;
+  z-index: 3;
+  left: 50%;
+  top: 50%;
+  width: 92px;
+  height: 92px;
+  transform: translate(-50%, -50%);
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background:
+    linear-gradient(to bottom, transparent, #000),
+    linear-gradient(to right, #fff, hsl(216, 76%, 52%));
+}
+.color-sv-thumb {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  margin-top: -6px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
+  left: 72%;
+  top: 22%;
+  pointer-events: none;
+}
+.color-corner {
+  position: absolute;
+  z-index: 5;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-glass-border);
+  transition: background 0.12s, border-color 0.12s;
+}
+.color-corner:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+.color-corner--white {
+  top: 0;
+  left: 0;
+  background: #fff;
+  border-color: rgba(0, 0, 0, 0.28);
+}
+.color-corner--black {
+  bottom: 0;
+  left: 0;
+  background: #000;
+  border-color: rgba(255, 255, 255, 0.35);
+  color: var(--color-text-muted);
+}
+.color-corner--eyedropper {
+  top: 0;
+  right: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--color-text-muted);
+}
+.color-corner--eyedropper:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: transparent;
+  border: none;
+  color: var(--color-text-muted);
+}
+.color-corner--transparent {
+  bottom: 0;
+  right: 0;
+  background-color: transparent;
+  background-image: repeating-conic-gradient(
+    rgba(255, 255, 255, 0.32) 0% 25%,
+    rgba(0, 0, 0, 0.28) 0% 50%
+  );
+  background-size: 8px 8px;
+  background-position: 50% 50%;
+  border-color: var(--color-glass-border);
 }
 .color-sliders {
   display: flex;
@@ -1025,35 +1234,37 @@ code {
   border: 1px solid var(--color-glass-border);
 }
 
-/* Scene 10 — transform numeric grid */
-.txn-grid {
+/* Scene 10 — transform popover: three rows (Scale / Translate / Rotate), label left, fields right */
+.tool-popover .transform-row {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 8px 10px;
+  grid-template-columns: 72px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
 }
-.txn-grid .cell {
+.tool-popover .transform-row-name {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  line-height: 1.2;
+}
+.tool-popover .transform-row-fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+}
+.tool-popover .transform-field {
   display: flex;
   align-items: center;
   gap: 8px;
 }
-.txn-grid .cell .row-label {
-  width: 24px;
+.tool-popover .transform-field-label {
+  width: 22px;
+  flex-shrink: 0;
   font-family: var(--font-geist-mono);
   font-size: 11px;
   font-weight: 500;
   color: var(--color-text-muted);
-}
-.txn-grid .reset-btn {
-  grid-column: 2;
-  justify-self: end;
-  height: 26px;
-  padding: 0 12px;
-  border-radius: 4px;
-  border: 1px solid var(--color-glass-border);
-  background: var(--color-glass-button-bg);
-  color: var(--color-text-secondary);
-  font-size: 11px;
-  cursor: pointer;
 }
 
 /* Scene 11 — equations list */
@@ -1079,16 +1290,30 @@ code {
   font-size: 13px;
   cursor: pointer;
 }
-.eq-add {
-  height: 30px;
-  padding: 0 12px;
-  border-radius: 6px;
-  border: 1px dashed rgba(var(--color-accent-rgb), 0.5);
-  background: transparent;
-  color: var(--color-accent-blue);
-  font-family: var(--font-geist-sans);
-  font-size: 11px;
-  font-weight: 500;
-  cursor: pointer;
-  align-self: flex-start;
+.tool-popover--equations .head {
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 32px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+.tool-popover--equations .head .head-title {
+  flex: 1;
+  min-width: 0;
+}
+/* Compact “+”: same accent treatment as active .sidebar-tool, not 40×40. */
+.tool-popover--equations .head .eq-popover-add.sidebar-tool {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+}
+.tool-popover--equations .head .eq-popover-add.sidebar-tool svg {
+  width: 14px;
+  height: 14px;
+}
+/* Match default + hover chrome of .editor-topbar .sidebar-tool (e.g. Weight when inactive). */
+.tool-popover--equations .head .eq-popover-add:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: transparent;
+  color: var(--color-text-muted);
 }

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -64,8 +64,8 @@ body {
  *     <EditorSidebar diagrams={diagrams} />
  *   </div>
  * Width fixed at 1728, height 1080, no scrollbars. CSS var
- * `--sidebar-offset` lets the top-left toolbar mirror the sidebar's
- * width — same behaviour as the live app.
+ * `--sidebar-offset` mirrors the rail width so canvas chrome aligns with the
+ * sidebar (rail is always visible in this wireframe — not collapsible).
  */
 
 .editor-frame {
@@ -78,12 +78,6 @@ body {
   border-radius: 10px;
   overflow: hidden;
   background: var(--color-canvas-bg);
-}
-.editor-frame.is-sidebar-closed {
-  --sidebar-offset: 0px;
-}
-.editor-frame.is-sidebar-closed .sidebar {
-  width: 0;
 }
 
 /* Canvas dot grid (mirrors React Flow <Background variant="dots" gap={20} size={1} />) */
@@ -100,8 +94,8 @@ body {
  * 56-wide vertical rail. The buttons mirror the user-facing slots of
  * `Shape<K>` in components/editor/types.ts (lines 116-126):
  *
- *   slot (-1) name       → tool-name        — pencil glyph
- *   slot  (0) points     → tool-points      — two dots
+ *   slot (-1) name       → tool-name        — Geist “A” (label)
+ *   slot  (0) points     → tool-points      — two dots, wider spacing
  *   slot  (1) kind       → tool-kind        — triangle (representative kind)
  *   slot  (2) order      → tool-order       — three ascending bars
  *   slot  (3) color      → tool-color       — filled disk in current shape color
@@ -128,10 +122,7 @@ body {
   flex-direction: column;
   z-index: 2;
   overflow: hidden;
-  transition: width 200ms;
 }
-/* Inner content keeps its 56 width even when the outer collapses so the
-   collapse looks like a slide rather than a reflow (matches the live app). */
 .sidebar > .sidebar-inner {
   width: 56px;
   height: 100%;
@@ -199,40 +190,19 @@ body {
   stroke: rgba(255, 255, 255, 0.45);
   stroke-width: 1;
 }
+/* `tool-name` — letterform inside <use>; avoid fill:none from .sidebar-tool svg leaking via inheritance. */
+.sidebar-tool.tool-name svg {
+  width: 20px;
+  height: 20px;
+  stroke: none;
+  fill: currentColor;
+}
+
 /* `tool-points` and `tool-equations` glyphs read better as filled shapes. */
 .sidebar-tool.tool-points svg,
 .sidebar-tool.tool-equations svg {
   fill: currentColor;
   stroke: none;
-}
-
-/* Collapse handle — sits at the right edge of the sidebar (or at the left
-   edge of the canvas when collapsed). Positioned on `.editor-frame` rather
-   than inside `.sidebar` so `.sidebar { overflow: hidden }` doesn't clip it.
-   `left: var(--sidebar-offset)` makes the handle slide with the sidebar. */
-.sidebar-handle {
-  position: absolute;
-  top: 50%;
-  left: var(--sidebar-offset, 56px);
-  transform: translateY(-50%);
-  width: 28px;
-  height: 64px;
-  display: grid;
-  place-items: center;
-  border-top-right-radius: 8px;
-  border-bottom-right-radius: 8px;
-  border: 1px solid var(--color-glass-border);
-  border-left: none;
-  background: var(--color-glass-panel-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  color: var(--color-text-muted);
-  font-family: var(--font-geist-sans);
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
-  z-index: 11;
-  transition: left 200ms;
 }
 
 /* ───────── Canvas area ───────── */
@@ -246,7 +216,7 @@ body {
 /* ───────── Top-left toolbar (Kinds + Straight) ───────── */
 /*
  * position: absolute; top: 12; left: calc(12 + var(--sidebar-offset));
- * display: flex; gap: 8; align-items: flex-start; transition 200ms.
+ * display: flex; gap: 8; align-items: flex-start.
  * Each button uses panelStyle() + borderRadius 8 + padding 6px 14px,
  * 12px / 600wt / secondary text.
  */
@@ -423,7 +393,7 @@ body {
 
 /* ───────── Bottom-left zoom controls (React Flow <Controls />) ─────────
  * Styled in app/globals.css .react-flow__controls: glass panel, 28x28
- * buttons stacked vertically, glass-border between, sidebar-offset slide.
+ * buttons stacked vertically, glass-border between; left inset uses --sidebar-offset.
  */
 
 .controls-cluster {
@@ -561,4 +531,365 @@ code {
   padding: 1px 6px;
   border-radius: 4px;
   font-size: 0.92em;
+}
+
+/* ───────── Tool popovers (rail button → editor panel) ─────────
+ *
+ * One popover per rail button. Floats just to the right of the 56-wide rail
+ * at the y-position of the originating button. Anchored to `.editor-frame`.
+ * Structure: header (caption) → body (editor) → vis-footer (3-state
+ * "Off · Selected · All"). The visibility footer is parked at the bottom
+ * per the user's choice — editor stays in the visual foreground.
+ */
+
+.tool-popover {
+  position: absolute;
+  left: calc(var(--sidebar-offset) + 8px);
+  z-index: 12;
+  min-width: 240px;
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.tool-popover .head {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-glass-border);
+  font-family: var(--font-geist-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.tool-popover .body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.tool-popover .body .body-label {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+.tool-popover .body .hint {
+  font-size: 11px;
+  color: var(--color-text-dimmed);
+  line-height: 1.4;
+}
+.tool-popover .vis-footer {
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--color-glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.02);
+}
+.tool-popover .vis-footer .footer-label {
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-text-dimmed);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* 3-state visibility segmented control */
+.vis-seg {
+  display: flex;
+  gap: 4px;
+  background: var(--color-glass-button-bg);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 6px;
+  padding: 2px;
+}
+.vis-seg .seg {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-geist-sans);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: center;
+}
+.vis-seg .seg:hover  { color: var(--color-text-secondary); }
+.vis-seg .seg.is-on {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  border-color: rgba(var(--color-accent-rgb), 0.5);
+  color: var(--color-text-primary);
+}
+
+/* Shared form controls inside the popover body */
+.tool-popover .text-input {
+  width: 100%;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 6px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-geist-sans);
+  font-size: 13px;
+  outline: none;
+}
+.tool-popover .num-input {
+  width: 56px;
+  height: 26px;
+  padding: 0 6px;
+  border-radius: 6px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-geist-mono);
+  font-size: 12px;
+  text-align: center;
+  outline: none;
+}
+
+/* Scene 7 — kind picker (5 shape tiles) */
+.kind-picker {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 18px;          /* room for the tile-label below */
+}
+.kind-picker .tile {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  position: relative;
+}
+.kind-picker .tile.is-on {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  border-color: rgba(var(--color-accent-rgb), 0.5);
+  color: var(--color-text-primary);
+}
+.kind-picker .tile svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.4;
+  stroke-linejoin: round;
+}
+.kind-picker .tile .tile-label {
+  position: absolute;
+  bottom: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-geist-mono);
+  font-size: 9px;
+  color: var(--color-text-dimmed);
+  white-space: nowrap;
+}
+
+/* Scenes 8 + 12 — vertical slider (Fresco "Tamaño 6,0" style) */
+.slider-col {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+}
+.slider-col .slider-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+.slider-col .slider-track {
+  position: relative;
+  width: 4px;
+  height: 200px;
+  background: var(--color-glass-button-bg);
+  border-radius: 2px;
+}
+.slider-col .slider-thumb {
+  position: absolute;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-accent-blue);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  transform: translate(-50%, -50%);
+}
+.slider-col .slider-notches {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 200px;
+  padding-top: 0;
+}
+.slider-col .slider-notches span {
+  font-family: var(--font-geist-mono);
+  font-size: 9px;
+  color: var(--color-text-dimmed);
+  line-height: 1;
+}
+.slider-col .preview-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+.slider-col .preview-disk {
+  border-radius: 50%;
+  background: rgba(var(--color-accent-rgb), 0.35);
+  border: 1px solid rgba(var(--color-accent-rgb), 0.7);
+}
+
+/* Scene 9 — color picker */
+.color-wheel {
+  width: 220px;
+  height: 220px;
+  position: relative;
+  margin: 0 auto;
+}
+.color-current {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--color-accent-blue);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+}
+.color-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.color-sliders .slider-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.color-sliders .slider-row .row-label {
+  width: 16px;
+  font-family: var(--font-geist-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+.color-sliders .slider-row .h-track {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  position: relative;
+}
+.color-sliders .slider-row .h-track.hue {
+  background: linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
+}
+.color-sliders .slider-row .h-track.sat {
+  background: linear-gradient(to right, rgba(255,255,255,0.1), rgb(59,130,246));
+}
+.color-sliders .slider-row .h-track.val {
+  background: linear-gradient(to right, #000, rgb(59,130,246));
+}
+.color-sliders .slider-row .h-track.alpha {
+  background:
+    linear-gradient(to right, rgba(59,130,246,0), rgb(59,130,246)),
+    repeating-conic-gradient(rgba(255,255,255,0.2) 0% 25%, transparent 0% 50%) 0 0 / 8px 8px;
+}
+.color-sliders .slider-row .h-thumb {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  transform: translate(-50%, -50%);
+}
+.swatches {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+}
+.swatches .sw {
+  aspect-ratio: 1;
+  border-radius: 4px;
+  border: 1px solid var(--color-glass-border);
+}
+
+/* Scene 10 — transform numeric grid */
+.txn-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px 10px;
+}
+.txn-grid .cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.txn-grid .cell .row-label {
+  width: 24px;
+  font-family: var(--font-geist-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+.txn-grid .reset-btn {
+  grid-column: 2;
+  justify-self: end;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 4px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+/* Scene 11 — equations list */
+.eq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.eq-row {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--color-glass-button-bg);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 4px;
+  font-family: var(--font-geist-mono);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.eq-row .delete {
+  margin-left: auto;
+  color: var(--color-text-dimmed);
+  font-size: 13px;
+  cursor: pointer;
+}
+.eq-add {
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px dashed rgba(var(--color-accent-rgb), 0.5);
+  background: transparent;
+  color: var(--color-accent-blue);
+  font-family: var(--font-geist-sans);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: flex-start;
 }

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -79,6 +79,12 @@ body {
   overflow: hidden;
   background: var(--color-canvas-bg);
 }
+.editor-frame.is-sidebar-closed {
+  --sidebar-offset: 0px;
+}
+.editor-frame.is-sidebar-closed .sidebar {
+  width: 0;
+}
 
 /* Canvas dot grid (mirrors React Flow <Background variant="dots" gap={20} size={1} />) */
 .editor-frame .canvas-bg {
@@ -110,6 +116,15 @@ body {
   flex-direction: column;
   z-index: 2;
   overflow: hidden;
+  transition: width 200ms;
+}
+/* Inner content keeps its 240 width even when the outer collapses so the
+   collapse looks like a slide rather than a reflow (matches the live app). */
+.sidebar > .sidebar-inner {
+  width: 240px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar-brand {
@@ -166,6 +181,7 @@ body {
   border: 1px solid var(--color-glass-border);
   background: var(--color-glass-button-bg);
   color: var(--color-text-muted);
+  font-family: var(--font-geist-sans);
   font-size: 18px;
   font-weight: 600;
   line-height: 1;
@@ -189,28 +205,33 @@ body {
 .diagram-row .title { color: var(--color-text-primary); font-size: 13px; font-weight: 500; line-height: 1.3; }
 .diagram-row .meta { color: var(--color-text-dimmed); font-size: 11px; line-height: 1.3; }
 
-/* Collapse arrow — small attached tab on the right edge of the sidebar.
-   Matches the visual in production: tall pill, glass background. */
-.sidebar-collapse {
+/* Collapse handle — sits at the right edge of the sidebar (or at the left
+   edge of the canvas when collapsed). Positioned on `.editor-frame` rather
+   than inside `.sidebar` so `.sidebar { overflow: hidden }` doesn't clip it.
+   `left: var(--sidebar-offset)` makes the handle slide with the sidebar. */
+.sidebar-handle {
   position: absolute;
   top: 50%;
-  right: -28px;
+  left: var(--sidebar-offset, 240px);
   transform: translateY(-50%);
   width: 28px;
-  height: 56px;
+  height: 64px;
   display: grid;
   place-items: center;
-  border-top-right-radius: 6px;
-  border-bottom-right-radius: 6px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border: 1px solid var(--color-glass-border);
   border-left: none;
   background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
   -webkit-backdrop-filter: blur(var(--effect-blur));
   color: var(--color-text-muted);
-  font-size: 14px;
+  font-family: var(--font-geist-sans);
+  font-size: 16px;
+  line-height: 1;
   cursor: pointer;
-  z-index: 3;
+  z-index: 11;
+  transition: left 200ms;
 }
 
 /* ───────── Canvas area ───────── */

--- a/_design/02-wireframe/styles.css
+++ b/_design/02-wireframe/styles.css
@@ -1,7 +1,18 @@
 /*
- * Wireframe styles for the editor's chrome. Low-fidelity, structural only.
- * Pulls the design system tokens via the import below so the wireframe
- * inherits the NeSyCat dark-glass feel automatically.
+ * Editor chrome wireframe — sized and styled to match what ships today,
+ * pixel-precise where the source code is precise.
+ *
+ * Reference resolution: MacBook Pro 16" M-series, default scaled at
+ * 1728 × 1117 effective points. Each scene frame is 1728 × 1080 to mirror
+ * the real viewport once the macOS chrome is removed.
+ *
+ * Token + styling sources cited inline next to each rule:
+ *   EditorSidebar.tsx           — sidebar
+ *   Canvas.tsx (Kinds toolbar)  — top-left
+ *   Canvas.tsx (KindRow + Kbd)  — Kinds menu
+ *   Canvas.tsx (JSON panel)     — top-right
+ *   ReactFlow <Controls/>       — bottom-left zoom cluster
+ *   ../00-design-system/tokens.css — colours + typography
  */
 
 @import url("../00-design-system/tokens.css");
@@ -19,18 +30,20 @@ body {
 /* ───────── Page chrome ───────── */
 
 .page-header {
-  padding: 28px 40px 8px;
-  border-bottom: 1px solid var(--color-glass-border);
+  padding: 36px 40px 16px;
+  max-width: 1808px;          /* 1728 frame + 40 each side, room for shadow */
+  margin: 0 auto;
 }
 .page-header p {
-  max-width: 720px;
+  max-width: 760px;
   color: var(--color-text-muted);
   margin: 8px 0 0;
 }
 
 .wireframe-section {
-  padding: 24px 40px 56px;
-  border-bottom: 1px solid var(--color-glass-border);
+  max-width: 1808px;
+  margin: 0 auto;
+  padding: 32px 40px 64px;
 }
 .wireframe-section h2 {
   margin: 0 0 4px;
@@ -40,339 +53,395 @@ body {
   margin: 0 0 24px;
   font-size: 14px;
   line-height: 1.6;
-  max-width: 720px;
+  max-width: 760px;
 }
 
-/* ───────── Editor frame (the wireframe canvas) ───────── */
+/* ───────── Editor frame (one scene = one viewport) ───────── */
+/*
+ * Matches `app/editor/layout.tsx`:
+ *   <div className="relative h-screen w-screen overflow-hidden">
+ *     <main className="absolute inset-0">{Canvas}</main>
+ *     <EditorSidebar diagrams={diagrams} />
+ *   </div>
+ * Width fixed at 1728, height 1080, no scrollbars. CSS var
+ * `--sidebar-offset` lets the top-left toolbar mirror the sidebar's
+ * width — same behaviour as the live app.
+ */
 
 .editor-frame {
+  --sidebar-offset: 240px;
   position: relative;
-  width: 100%;
-  height: 720px;
-  border: 1px dashed var(--color-glass-border);
-  border-radius: var(--size-radius-md);
+  width: 1728px;
+  height: 1080px;
+  max-width: 100%;
+  border: 1px solid var(--color-glass-border);
+  border-radius: 10px;
   overflow: hidden;
   background: var(--color-canvas-bg);
-  display: grid;
-  grid-template-columns: 240px 1fr;
-  /* Faint dot grid mimicking the React Flow background. */
-  background-image: radial-gradient(var(--canvas-grid-color) 1px, transparent 1px);
-  background-size: 12px 12px;
 }
 
-/* ───────── Left sidebar ───────── */
+/* Canvas dot grid (mirrors React Flow <Background variant="dots" gap={20} size={1} />) */
+.editor-frame .canvas-bg {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(var(--canvas-grid-color) 1px, transparent 1px);
+  background-size: 20px 20px;
+  z-index: 0;
+}
+
+/* ───────── Left sidebar (EditorSidebar.tsx) ───────── */
+/*
+ * width 240, glass-panel-bg, 3px backdrop blur, border-right glass-border.
+ * Brand row: 14px vert padding, 16px horiz, 10px gap, border-bottom.
+ * Brand text: 15px, 600wt, primary, -0.3px letter-spacing.
+ */
 
 .sidebar {
-  position: relative;
-  border-right: 1px solid var(--color-glass-border);
-  background: rgba(15, 15, 20, 0.55);
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 240px;
+  background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
   -webkit-backdrop-filter: blur(var(--effect-blur));
+  border-right: 1px solid var(--color-glass-border);
   display: flex;
   flex-direction: column;
   z-index: 2;
+  overflow: hidden;
 }
+
 .sidebar-brand {
-  padding: 18px 16px 10px;
   display: flex;
   align-items: center;
   gap: 10px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--color-glass-border);
+  text-decoration: none;
 }
-.sidebar-brand .logo-mark {
-  width: 22px;
-  height: 22px;
-  border-radius: 5px;
-  border: 1.3px solid var(--color-accent-blue);
-  background: rgba(var(--color-accent-rgb), 0.15);
-  position: relative;
+.sidebar-brand:hover { background: rgba(255, 255, 255, 0.05); }
+.sidebar-brand .brand-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  letter-spacing: -0.3px;
+  white-space: nowrap;
 }
-.sidebar-brand .logo-mark::after {
-  content: "";
-  position: absolute;
-  inset: 4px;
-  border: 1.3px solid var(--color-accent-blue);
-  transform: rotate(45deg);
-  background: rgba(var(--color-accent-rgb), 0.22);
-}
-.sidebar-brand .name { font-weight: 600; font-size: 15px; color: var(--color-text-primary); letter-spacing: -0.3px; }
-.sidebar-search {
+
+/* Inline SVG logo mark (matches LogoMark in EditorSidebar.tsx). */
+.logo-mark { width: 22px; height: 22px; flex-shrink: 0; }
+
+.sidebar-search-row {
   display: flex;
+  align-items: center;
   gap: 8px;
-  padding: 12px 12px 8px;
+  padding: 12px 12px 0;
+}
+.sidebar-search {
+  position: relative;
+  flex: 1;
+  min-width: 0;
 }
 .sidebar-search input {
-  flex: 1;
-  background: var(--color-glass-button-bg);
-  border: 1px solid var(--color-glass-border);
-  border-radius: 6px;
-  color: var(--color-text-secondary);
-  font-family: inherit;
-  font-size: 13px;
-  padding: 7px 10px;
-  outline: none;
-}
-.sidebar-search input::placeholder { color: var(--color-text-dimmed); }
-.sidebar-search .plus {
-  width: 30px;
-  height: 30px;
-  display: grid;
-  place-items: center;
+  width: 100%;
+  height: 36px;
+  padding: 0 12px;
   border-radius: 6px;
   border: 1px solid var(--color-glass-border);
   background: var(--color-glass-button-bg);
   color: var(--color-text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+}
+.sidebar-search input::placeholder { color: var(--color-text-dimmed); }
+.sidebar-new {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass-button-bg);
+  color: var(--color-text-muted);
   font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
   cursor: pointer;
 }
+
 .sidebar-list {
   flex: 1;
   overflow: auto;
-  padding: 4px 0;
+  padding-top: 12px;
 }
 .diagram-row {
-  padding: 10px 14px;
+  padding: 10px 16px;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   gap: 2px;
-  border-bottom: 1px solid var(--color-glass-border);
-  cursor: pointer;
 }
+.diagram-row:hover { background: rgba(255, 255, 255, 0.04); }
 .diagram-row.active { background: rgba(var(--color-accent-rgb), 0.10); }
-.diagram-row .title { color: var(--color-text-primary); font-size: 13px; font-weight: 500; }
-.diagram-row .meta { color: var(--color-text-dimmed); font-family: var(--font-geist-mono); font-size: 10px; }
+.diagram-row .title { color: var(--color-text-primary); font-size: 13px; font-weight: 500; line-height: 1.3; }
+.diagram-row .meta { color: var(--color-text-dimmed); font-size: 11px; line-height: 1.3; }
 
+/* Collapse arrow — small attached tab on the right edge of the sidebar.
+   Matches the visual in production: tall pill, glass background. */
 .sidebar-collapse {
   position: absolute;
   top: 50%;
-  right: -14px;
-  width: 22px;
-  height: 32px;
+  right: -28px;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 56px;
   display: grid;
   place-items: center;
-  border-radius: 4px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border: 1px solid var(--color-glass-border);
+  border-left: none;
   background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
   color: var(--color-text-muted);
-  font-size: 12px;
+  font-size: 14px;
   cursor: pointer;
   z-index: 3;
 }
 
-/* ───────── Canvas placeholder ───────── */
+/* ───────── Canvas area ───────── */
 
 .canvas-area {
-  position: relative;
-  overflow: hidden;
-}
-.canvas-placeholder {
   position: absolute;
-  inset: 96px 80px 96px 24px;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  border-radius: 10px;
-  display: grid;
-  place-items: center;
-  text-align: center;
-  padding: 32px;
-  color: var(--color-text-muted);
-  font-size: 13px;
-  line-height: 1.6;
+  inset: 0;
+  z-index: 1;
 }
-.canvas-placeholder strong { color: var(--color-text-primary); }
 
-/* ───────── Floating toolbars ───────── */
+/* ───────── Top-left toolbar (Kinds + Straight) ───────── */
+/*
+ * position: absolute; top: 12; left: calc(12 + var(--sidebar-offset));
+ * display: flex; gap: 8; align-items: flex-start; transition 200ms.
+ * Each button uses panelStyle() + borderRadius 8 + padding 6px 14px,
+ * 12px / 600wt / secondary text.
+ */
 
-.glass-bar {
+.toolbar-topleft {
   position: absolute;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px;
+  top: 12px;
+  left: calc(12px + var(--sidebar-offset));
+  z-index: 10;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.panel-btn {
   background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
   -webkit-backdrop-filter: blur(var(--effect-blur));
   border: 1px solid var(--color-glass-border);
-  border-radius: var(--size-radius-md);
-  z-index: 4;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-family: var(--font-geist-sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
 }
-.glass-btn {
+
+/* Kinds button + its drop-down container */
+.kinds-anchor {
+  position: relative;
+}
+.kinds-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  padding-top: 6px;          /* gap from button (matches Canvas.tsx: paddingTop: 6) */
+  z-index: 10;
+}
+.kinds-menu .panel {
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: 8px;
+  padding: 6px 6px;
+  min-width: 220px;
+}
+/* KindRow — Canvas.tsx 730-755 */
+.kind-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-dimmed);
+  cursor: pointer;
+  user-select: none;
+}
+.kind-row.is-on  { color: var(--color-text-secondary); }
+.kind-row:hover  { background: rgba(255, 255, 255, 0.04); }
+.kind-row .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: transparent;
+  margin-left: 2px;
+  flex-shrink: 0;
+}
+.kind-row.is-on .dot {
+  background: rgba(var(--color-accent-rgb), 0.9);
+  border-color: transparent;
+  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.2);
+}
+.kind-row .label { flex: 1; }
+.kind-row .kbds {
+  margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 7px 11px;
-  border-radius: 6px;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--color-text-secondary);
-  font-size: 12px;
-  font-family: inherit;
-  cursor: pointer;
+  gap: 3px;
 }
-.glass-btn:hover { background: var(--color-glass-button-bg); border-color: var(--color-glass-border); }
-.glass-btn.is-primary {
-  background: rgba(var(--color-accent-rgb), 0.22);
-  border-color: rgba(var(--color-accent-rgb), 0.7);
-  color: var(--color-text-primary);
-}
-
-.toolbar-topleft {
-  top: 12px;
-  left: 12px;
-}
-.toolbar-topleft .divider {
-  width: 1px;
-  height: 18px;
-  background: var(--color-glass-border);
-  margin: 0 2px;
-}
-.toolbar-toggle {
+/* Kbd — Canvas.tsx 715-727 */
+.kbd {
   display: inline-flex;
-  border-radius: 6px;
-  overflow: hidden;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
   border: 1px solid var(--color-glass-border);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text-secondary);
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0;
+  white-space: nowrap;
 }
-.toolbar-toggle .glass-btn { border-radius: 0; border: none; padding: 6px 10px; }
-.toolbar-toggle .glass-btn.is-active { background: var(--color-glass-button-bg); color: var(--color-text-primary); }
 
-.json-panel-closed { top: 12px; right: 12px; }
-.json-panel-open {
+/* ───────── Top-right JSON button + panel (Canvas.tsx 671-710) ───────── */
+
+.topright {
+  position: absolute;
   top: 12px;
   right: 12px;
-  width: 320px;
-  height: 280px;
+  z-index: 10;
+  display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 0;
-  padding: 0;
+  gap: 8px;
+  align-items: flex-end;
 }
-.json-panel-open .header {
+
+.json-panel {
+  width: 400px;
+  max-height: 500px;
+  background: var(--color-glass-panel-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.json-panel .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 10px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--color-glass-border);
 }
-.json-panel-open .header .left { display: flex; gap: 6px; align-items: center; }
-.json-panel-open .body {
-  flex: 1;
-  overflow: auto;
-  padding: 12px;
+.json-panel .header .label {
   font-family: var(--font-geist-mono);
   font-size: 11px;
+  font-weight: 600;
   color: var(--color-text-muted);
-  background: rgba(0, 0, 0, 0.25);
-  white-space: pre;
-  line-height: 1.5;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
+.json-panel .header .actions {
+  display: flex;
+  gap: 6px;
+}
+.json-panel .header .actions button {
+  background: var(--color-glass-button-bg);
+  backdrop-filter: blur(var(--effect-blur));
+  -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: 4px;
+  color: var(--color-text-secondary);
+  font-family: var(--font-geist-sans);
+  font-size: 11px;
+  padding: 2px 10px;
+  cursor: pointer;
+}
+.json-panel .body {
+  flex: 1;
+  margin: 0;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--color-text-muted);
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  white-space: pre;
+  overflow: auto;
+}
+
+/* ───────── Bottom-left zoom controls (React Flow <Controls />) ─────────
+ * Styled in app/globals.css .react-flow__controls: glass panel, 28x28
+ * buttons stacked vertically, glass-border between, sidebar-offset slide.
+ */
 
 .controls-cluster {
   position: absolute;
   bottom: 12px;
-  left: 12px;
-  display: inline-flex;
-  flex-direction: column;
-  border: 1px solid var(--color-glass-border);
-  border-radius: var(--size-radius-md);
+  left: calc(12px + var(--sidebar-offset));
+  z-index: 10;
   background: var(--color-glass-panel-bg);
   backdrop-filter: blur(var(--effect-blur));
   -webkit-backdrop-filter: blur(var(--effect-blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: 8px;
   overflow: hidden;
-  z-index: 4;
+  display: flex;
+  flex-direction: column;
 }
 .controls-cluster button {
   width: 28px;
   height: 28px;
   border: none;
+  border-bottom: 1px solid var(--color-glass-border);
   background: transparent;
   color: var(--color-text-secondary);
-  border-bottom: 1px solid var(--color-glass-border);
+  display: grid;
+  place-items: center;
   cursor: pointer;
 }
 .controls-cluster button:last-child { border-bottom: none; }
+.controls-cluster button:hover { background: var(--color-glass-button-bg); }
+.controls-cluster svg { width: 14px; height: 14px; fill: currentColor; }
 
-/* ───────── Annotation column ───────── */
-
-.with-annotations {
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  gap: 24px;
-}
-.annotations {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  line-height: 1.6;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-.annotations .note {
-  border-left: 2px solid rgba(var(--color-accent-rgb), 0.6);
-  padding: 6px 10px;
-  background: var(--color-glass-button-bg);
-  border-radius: 4px;
-}
-.annotations .note .pin {
-  display: inline-block;
-  font-family: var(--font-geist-mono);
-  font-size: 10px;
-  color: var(--color-accent-blue);
-  margin-right: 6px;
-}
-.annotations h3 { color: var(--color-text-primary); font-size: 13px; margin: 12px 0 4px; }
-
-/* ───────── Open Kinds menu (separate state) ───────── */
-
-.kinds-menu {
-  position: absolute;
-  top: 56px;
-  left: 12px;
-  width: 240px;
-  padding: 6px;
-  background: var(--color-glass-panel-bg);
-  backdrop-filter: blur(var(--effect-blur));
-  -webkit-backdrop-filter: blur(var(--effect-blur));
-  border: 1px solid var(--color-glass-border);
-  border-radius: var(--size-radius-md);
-  z-index: 4;
-}
-.kinds-menu .row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 7px 10px;
-  font-size: 12px;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  border-radius: 4px;
-}
-.kinds-menu .row:hover { background: var(--color-glass-button-bg); }
-.kinds-menu .row.is-toggled .name { color: var(--color-text-primary); }
-.kinds-menu .row .name { display: flex; align-items: center; gap: 8px; }
-.kinds-menu .row .hint {
-  font-family: var(--font-geist-mono);
-  font-size: 10px;
-  color: var(--color-text-dimmed);
-}
-.kinds-menu .divider { height: 1px; background: var(--color-glass-border); margin: 6px 4px; }
-.kinds-menu .check {
-  width: 14px;
-  height: 14px;
-  border: 1px solid var(--color-glass-border);
-  border-radius: 3px;
-}
-.kinds-menu .check.on {
-  background: rgba(var(--color-accent-rgb), 0.5);
-  border-color: rgba(var(--color-accent-rgb), 0.8);
-}
-
-/* ───────── Star-prompt modal (alternate state) ───────── */
+/* ───────── Star-prompt modal (StarPrompt.tsx) ───────── */
 
 .modal-frame {
   position: relative;
-  width: 100%;
-  height: 360px;
-  border: 1px dashed var(--color-glass-border);
-  border-radius: var(--size-radius-md);
+  width: 1728px;
+  height: 600px;
+  max-width: 100%;
+  border: 1px solid var(--color-glass-border);
+  border-radius: 10px;
   overflow: hidden;
   background: var(--color-canvas-bg);
 }
@@ -384,31 +453,34 @@ body {
   place-items: center;
 }
 .modal-body {
-  width: 380px;
-  padding: 28px;
+  width: 420px;
+  padding: 32px;
   background: var(--color-canvas-bg);
   border: 1px solid var(--color-glass-border);
   border-radius: 12px;
-  text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 14px;
   align-items: center;
+  gap: 14px;
+  text-align: center;
 }
 .modal-body .star {
-  width: 44px; height: 44px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   background: rgba(var(--color-accent-rgb), 0.18);
   border: 1px solid rgba(var(--color-accent-rgb), 0.5);
-  display: grid; place-items: center;
+  display: grid;
+  place-items: center;
   color: var(--color-accent-blue);
-  font-size: 20px;
+  font-size: 22px;
 }
 .modal-body .btn-row {
   display: flex;
   gap: 10px;
   width: 100%;
   justify-content: center;
+  margin-top: 8px;
 }
 .modal-body .btn {
   flex: 1;
@@ -417,6 +489,7 @@ body {
   border: 1px solid var(--color-glass-border);
   background: var(--color-glass-button-bg);
   color: var(--color-text-secondary);
+  font-family: inherit;
   font-size: 13px;
   cursor: pointer;
 }
@@ -424,4 +497,46 @@ body {
   background: rgba(var(--color-accent-rgb), 0.22);
   border-color: rgba(var(--color-accent-rgb), 0.7);
   color: var(--color-text-primary);
+}
+
+/* ───────── Annotations (below each scene, single column) ───────── */
+
+.annotations {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 24px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+}
+.annotations .note {
+  border-left: 2px solid rgba(var(--color-accent-rgb), 0.6);
+  padding: 4px 12px;
+  background: var(--color-glass-button-bg);
+  border-radius: 4px;
+}
+.annotations .note .pin {
+  display: inline-block;
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  color: var(--color-accent-blue);
+  margin-right: 6px;
+  letter-spacing: 0.04em;
+}
+.annotations h3 {
+  grid-column: 1 / -1;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  margin: 8px 0 0;
+  font-weight: 600;
+}
+
+code {
+  font-family: var(--font-geist-mono);
+  color: var(--color-text-secondary);
+  background: var(--color-glass-button-bg);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.92em;
 }

--- a/_design/README.md
+++ b/_design/README.md
@@ -4,9 +4,20 @@ Visual design pipeline, mirroring `02-Design.01..04` from the project taxonomy.
 
 | Folder | Phase | Output |
 |---|---|---|
+| `00-design-system/` | tokens + style guide | CSS vars + typography utilities (copied from the app) |
 | `01-sketch/` | hand-sketches | `.pdf`, `.pic` |
 | `02-wireframe/` | structure | HTML+CSS, no styling fidelity |
 | `03-mockup/` | full visual | HTML+CSS, pixel-perfect |
 | `04-prototype/` | interactive | HTML+CSS+JS |
 
-Each phase's output is the next phase's input. The final prototype is what gets translated into React inside `/app/` and `/components/`.
+`00-design-system/` is a static reference, not a phase per se — it pulls the
+app's existing tokens (colours, typography, fonts, effects, shape palette)
+into one place so every later phase consumes the same primitives via
+`<link rel="stylesheet" href="../00-design-system/tokens.css">`. Source of
+truth still lives in the app (`app/globals.css`,
+`components/editor/style/theme.ts`, `components/editor/color.ts`); the copy
+here is for design-time iteration only.
+
+Each subsequent phase's output is the next phase's input. The final
+prototype is what gets translated into React inside `/app/` and
+`/components/`.


### PR DESCRIPTION
## Summary

Two iterations on the existing \`_design/\` pipeline, **neither touching the app**.

### 1. New phase: \`_design/00-design-system/\`
A static design-system reference at the front of the pipeline. Three files:

- **\`tokens.css\`** — verbatim copy of the app's \`:root\` CSS vars, the \`.t-*\` typography utilities, the SVG accent palette, and the TS-only opacity tiers from \`components/editor/style/theme.ts\`.
- **\`index.html\`** — one-page style guide rendering colour swatches, typography specimens, effect samples, shape palette tiers.
- **\`README.md\`** — what's here, source-of-truth pointers, how later phases consume \`tokens.css\`.

Geist Sans/Mono load over Google Fonts so the static HTML matches the app without depending on Next.js's runtime.

### 2. \`_design/02-wireframe/\` filled in
Replaces the previous \`<h1>02 — Wireframe</h1><p>Placeholder.</p>\` stub with a real low-fidelity wireframe of the editor's UI chrome:

- **Scene 1** — default state. Left sidebar (logo, search, \`+\`, diagram rows, collapse arrow), top-left toolbar (Kinds + Straight|Smooth), top-right JSON panel (closed), bottom-left zoom controls. Right-margin annotation column with redesign-hook notes.
- **Scene 2** — Kinds menu open. Drops below the toolbar with shape kinds + Points/Lines/Outlines + hotkey hints.
- **Scene 3** — JSON panel open. Glass panel ~320×280 with Export/Import header strip + JSON preview body.
- **Scene 4** — Star-prompt modal. Full-screen dim overlay with the modal body.

The React Flow canvas in the middle is **labelled as out of scope** (the redesign is about chrome, not the canvas itself or the inline node UI). Pulls tokens via \`@import url(\"../00-design-system/tokens.css\")\` so the wireframe inherits the dark-glass NeSyCat feel automatically.

### What's untouched
- \`app/\`, \`components/\`, \`lib/\`, \`_concept/\`, \`public/\` — none of it.
- \`_design/01-sketch/\`, \`_design/03-mockup/\`, \`_design/04-prototype/\` — stay as their existing stubs.

Top-level \`_design/README.md\` updated to list \`00-design-system/\` at the top of the phase table.

## Test plan

- [x] \`npx tsc --noEmit\` clean (no app imports from \`_design/\`).
- [x] Lint clean on touched code paths (no app code touched).
- [ ] Open \`_design/00-design-system/index.html\` in a browser — every token renders with name + value; Geist fonts load.
- [ ] Open \`_design/02-wireframe/index.html\` — four scenes render at viewport height; sidebar / top-left toolbar / JSON panel / zoom controls / Kinds menu / star modal all visible and labelled.
- [ ] PR's Vercel preview: \`/editor\` renders unchanged (the static \`_design/\` HTML files aren't routed by Next.js).

## Out of scope

- The React Flow canvas itself (shapes, points, wires, JSON spine).
- Inline node UI (double-click rename, slot \`+\` buttons).
- Anything beneath \`app/\` (data model, mutations, RLS).
- \`03-mockup/\` and \`04-prototype/\` content — handled in later iterations once the wireframe converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)